### PR TITLE
Update lookahead and connect it to new registry

### DIFF
--- a/SmartContracts/src/avs/PreconfTaskManager.sol
+++ b/SmartContracts/src/avs/PreconfTaskManager.sol
@@ -3,18 +3,18 @@ pragma solidity 0.8.25;
 
 import {ITaikoL1} from "../interfaces/taiko/ITaikoL1.sol";
 import {MerkleUtils} from "../libraries/MerkleUtils.sol";
+import {EIP4788} from "../libraries/EIP4788.sol";
+import {PreconfConstants} from "./libraries/PreconfConstants.sol";
 import {IPreconfTaskManager} from "../interfaces/IPreconfTaskManager.sol";
 import {IPreconfServiceManager} from "../interfaces/IPreconfServiceManager.sol";
-import {IRegistryCoordinator} from "eigenlayer-middleware/interfaces/IRegistryCoordinator.sol";
-import {IIndexRegistry} from "eigenlayer-middleware/interfaces/IIndexRegistry.sol";
+import {IPreconfRegistry} from "../interfaces/IPreconfRegistry.sol";
 import {ECDSA} from "openzeppelin-contracts/utils/cryptography/ECDSA.sol";
 import {IERC20} from "openzeppelin-contracts/token/ERC20/IERC20.sol";
 import {Initializable} from "openzeppelin-contracts-upgradeable/proxy/utils/Initializable.sol";
 
 contract PreconfTaskManager is IPreconfTaskManager, Initializable {
     IPreconfServiceManager internal immutable preconfServiceManager;
-    IRegistryCoordinator internal immutable registryCoordinator;
-    IIndexRegistry internal immutable indexRegistry;
+    IPreconfRegistry internal immutable preconfRegistry;
     ITaikoL1 internal immutable taikoL1;
 
     // EIP-4788
@@ -45,20 +45,14 @@ contract PreconfTaskManager is IPreconfTaskManager, Initializable {
     uint256 internal constant PROPOSED_BLOCK_BUFFER_SIZE = 256;
     mapping(uint256 blockId => IPreconfTaskManager.ProposedBlock proposedBlock) proposedBlocks;
 
-    // Maps the preconfer's wallet address to the hash tree root of their consensus layer
-    // BLS pub key (48  bytes)
-    mapping(address preconfer => bytes32 BLSPubKeyHashTreeRoot) internal consensusBLSPubKeyHashTreeRoots;
-
     constructor(
         IPreconfServiceManager _serviceManager,
-        IRegistryCoordinator _registryCoordinator,
-        IIndexRegistry _indexRegistry,
+        IPreconfRegistry _registry,
         ITaikoL1 _taikoL1,
         address _beaconBlockRootContract
     ) {
         preconfServiceManager = _serviceManager;
-        registryCoordinator = _registryCoordinator;
-        indexRegistry = _indexRegistry;
+        preconfRegistry = _registry;
         taikoL1 = _taikoL1;
         beaconBlockRootContract = _beaconBlockRootContract;
     }
@@ -84,26 +78,20 @@ contract PreconfTaskManager is IPreconfTaskManager, Initializable {
         uint256 lookaheadPointer,
         IPreconfTaskManager.LookaheadSetParam[] calldata lookaheadSetParams
     ) external payable {
-        // Do not allow block proposals if the preconfer has not registered the hash tree root of their
-        // consensus BLS pub key
-        if (consensusBLSPubKeyHashTreeRoots[msg.sender] == bytes32(0)) {
-            revert IPreconfTaskManager.ConsensusBLSPubKeyHashTreeRootNotRegistered();
-        }
-
         uint256 currentEpochTimestamp = _getEpochTimestamp(block.timestamp);
         address randomPreconfer = randomPreconfers[currentEpochTimestamp];
 
-        // Verify that the sender is a valid preconfer for the slot and has the right to propose an L2 block
+        // Verify that the sender is allowed to propose a block in this slot
+
         if (randomPreconfer != address(0) && msg.sender != randomPreconfer) {
             // Revert if the sender is not the randomly selected preconfer for the epoch
             revert IPreconfTaskManager.SenderIsNotTheFallbackPreconfer();
-        } else if (isLookaheadRequired(currentEpochTimestamp)) {
-            // The *current* epoch may require a lookahead in the following situations:
+        } else if (isLookaheadRequired(currentEpochTimestamp) || block.timestamp < lookahead[lookaheadTail].timestamp) {
+            // A fallback preconfer is selected randomly for the current epoch when
+            // - Lookahead is empty i.e the epoch has no L1 validators who are opted-in preconfers in the AVS
+            // - The previous lookahead for the epoch was invalidated
             // - It is the first epoch after this contract started offering services
-            // - The epoch has no L1 validators who are opted-in preconfers in the AVS
-            // - The previous lookahead for the epoch was invalidated/
-            //
-            // In all the above cases, we expect a preconfer to be randomly chosen as fallaback
+
             if (msg.sender != getFallbackPreconfer()) {
                 revert IPreconfTaskManager.SenderIsNotTheFallbackPreconfer();
             } else {
@@ -188,39 +176,20 @@ contract PreconfTaskManager is IPreconfTaskManager, Initializable {
     }
 
     /**
-     * @notice lashes an operator if the lookahead posted by them is incorrect
-     * @param lookaheadPointer Index at which the entry for the lookahead is incorrect
-     * @param slotTimestamp Timestamp of the slot for which the lookahead entry is incorrect
-     * @param expectedValidator Chunks for the validator present in the lookahead
-     * @param expectedValidatorIndex Index of the expected validator in beacon state validators list
-     * @param expectedValidatorProof Merkle proof of expected validator being a part of validators list
-     * @param actualValidatorIndex Index of the actual validator in beacon state validators list
-     * @param validatorsRoot Hash tree root of the beacon state validators list
-     * @param nr_validators Length of the validators list
-     * @param beaconStateProof Merkle proof of validators list being a part of the beacon state
-     * @param beaconStateRoot Hash tree root of the beacon state
-     * @param beaconBlockProofForState Merkle proof of beacon state root being a part of the beacon block
-     * @param beaconBlockProofForProposerIndex Merkle proof of actual validator's index being a part of the beacon block
+     * @notice Proves that the lookahead for a specific slot was incorrect
+     * @dev The logic in this function only works once the lookahead slot has passed. This is because
+     * we pull the proposer from a beacon block and verify if it is associated with the preconfer.
+     * @param lookaheadPointer The pointer to the lookahead entry that represents the incorrect slot
+     * @param slotTimestamp The timestamp of the slot for which the lookahead was incorrect
+     * @param validatorBLSPubKey The BLS public key of the validator who is proposed the block in the slot
+     * @param validatorInclusionProof The inclusion proof of the above validator in the Beacon state
      */
     function proveIncorrectLookahead(
         uint256 lookaheadPointer,
         uint256 slotTimestamp,
-        bytes32[8] memory expectedValidator,
-        uint256 expectedValidatorIndex,
-        bytes32[] memory expectedValidatorProof,
-        uint256 actualValidatorIndex,
-        bytes32 validatorsRoot,
-        uint256 nr_validators,
-        bytes32[] memory beaconStateProof,
-        bytes32 beaconStateRoot,
-        bytes32[] memory beaconBlockProofForState,
-        bytes32[] memory beaconBlockProofForProposerIndex
+        bytes memory validatorBLSPubKey,
+        EIP4788.InclusionProof memory validatorInclusionProof
     ) external {
-        // Prove that the expected validator has not been slashed on consensus layer
-        if (expectedValidator[3] == bytes32(0)) {
-            revert IPreconfTaskManager.ExpectedValidatorMustNotBeSlashed();
-        }
-
         uint256 epochTimestamp = _getEpochTimestamp(slotTimestamp);
 
         // The poster must not already be slashed
@@ -228,62 +197,62 @@ contract PreconfTaskManager is IPreconfTaskManager, Initializable {
             revert IPreconfTaskManager.PosterAlreadySlashedForTheEpoch();
         }
 
-        {
+        // Must not have missed dispute period
+        if (block.timestamp - slotTimestamp > DISPUTE_PERIOD) {
+            revert IPreconfTaskManager.MissedDisputeWindow();
+        }
+
+        // Verify that the sent validator is the one in Beacon state
+        EIP4788.verifyValidator(validatorBLSPubKey, _getBeaconBlockRoot(slotTimestamp), validatorInclusionProof);
+
+        // We pull the preconfer present at the required slot timestamp in the lookahead.
+        // If no preconfer is present for a slot, we simply use the 0-address to denote the preconfer.
+
+        address preconferInLookahead;
+        if (randomPreconfers[epochTimestamp] != address(0)) {
+            // If the epoch had a random preconfer, the lookahead was empty
+            preconferInLookahead = address(0);
+        } else {
             IPreconfTaskManager.LookaheadEntry memory lookaheadEntry =
                 lookahead[lookaheadPointer % LOOKAHEAD_BUFFER_SIZE];
 
-            // Timestamp of the slot that contains the incorrect entry must be in the correct range and within the
-            // dispute window.
-            if (block.timestamp - slotTimestamp > DISPUTE_PERIOD) {
-                revert IPreconfTaskManager.MissedDisputeWindow();
-            } else if (slotTimestamp > lookaheadEntry.timestamp || slotTimestamp <= lookaheadEntry.prevTimestamp) {
+            // Validate lookahead pointer
+            if (slotTimestamp > lookaheadEntry.timestamp || slotTimestamp <= lookaheadEntry.prevTimestamp) {
                 revert IPreconfTaskManager.InvalidLookaheadPointer();
             }
 
-            if (consensusBLSPubKeyHashTreeRoots[lookaheadEntry.preconfer] != expectedValidator[0]) {
-                // Revert if the expected validator's consensus BLS pub key's hash tree root does not match
-                // the one registered by the preconfer
-                revert IPreconfTaskManager.ExpectedValidatorIsIncorrect();
-            } else if (expectedValidatorIndex == actualValidatorIndex) {
-                revert IPreconfTaskManager.ExpectedAndActualValidatorAreSame();
+            if (lookaheadEntry.timestamp == slotTimestamp) {
+                // The slot was dedicated to a specific preconfer
+                preconferInLookahead = lookaheadEntry.preconfer;
+            } else {
+                // The slot was empty and it was the next preconfer who was expected to preconf in advanced.
+                // We still use the zero address because technically the slot itself was empty in the lookahead.
+                preconferInLookahead = address(0);
             }
         }
 
-        {
-            bytes32 expectedValidatorHashTreeRoot = MerkleUtils.merkleize(expectedValidator);
-            if (
-                !MerkleUtils.verifyProof(
-                    expectedValidatorProof, validatorsRoot, expectedValidatorHashTreeRoot, expectedValidatorIndex
-                )
-            ) {
-                // Revert if the proof that the expected validator is a part of the validator
-                // list in beacon state fails
-                revert IPreconfTaskManager.ValidatorProofFailed();
-            }
-        }
+        // Fetch the preconfer associated with the validator from the registry
 
-        {
-            bytes32 stateValidatorsHashTreeRoot = MerkleUtils.mixInLength(validatorsRoot, nr_validators);
-            if (MerkleUtils.verifyProof(beaconStateProof, beaconStateRoot, stateValidatorsHashTreeRoot, 11)) {
-                // Revert if the proof that the validator list is a part of the beacon state fails
-                revert IPreconfTaskManager.BeaconStateProofFailed();
-            }
-        }
+        // Reduce validator's BLS pub key to the pub key hash expected by the registry
+        bytes32 validatorPubKeyHash = keccak256(abi.encodePacked(bytes16(0), validatorBLSPubKey));
 
-        bytes32 beaconBlockRoot = _getBeaconBlockRoot(slotTimestamp);
+        // Retrieve the validator object
+        IPreconfRegistry.Validator memory validatorInRegistry = preconfRegistry.getValidator(validatorPubKeyHash);
 
-        if (MerkleUtils.verifyProof(beaconBlockProofForState, beaconBlockRoot, beaconStateRoot, 3)) {
-            // Revert if the proof for the beacon state being a part of the beacon block fails
-            revert IPreconfTaskManager.BeaconBlockProofForStateFailed();
-        }
-
+        // Retrieve the preconfer
+        address preconferInRegistry = validatorInRegistry.preconfer;
         if (
-            MerkleUtils.verifyProof(
-                beaconBlockProofForProposerIndex, beaconBlockRoot, MerkleUtils.toLittleEndian(actualValidatorIndex), 1
-            )
+            slotTimestamp < validatorInRegistry.startProposingAt
+                || (validatorInRegistry.stopProposingAt != 0 && slotTimestamp > validatorInRegistry.stopProposingAt)
         ) {
-            // Revert if the proof that the proposer index is a part of the beacon block fails
-            revert IPreconfTaskManager.BeaconBlockProofForProposerIndex();
+            // The validator is no longer allowed to propose for the former preconfer
+            preconferInRegistry = address(0);
+        }
+
+        // Revert if the lookahead preconfer matches the one that the validator pulled from beacon state
+        // is proposing for
+        if (preconferInLookahead == preconferInRegistry) {
+            revert IPreconfTaskManager.LookaheadEntryIsCorrect();
         }
 
         // Slash the original lookahead poster
@@ -294,22 +263,11 @@ contract PreconfTaskManager is IPreconfTaskManager, Initializable {
         emit ProvedIncorrectLookahead(poster, slotTimestamp, msg.sender);
     }
 
-    function registerConsensusBLSPubKeyHashTreeRoot(bytes32 consensusBLSPubKeyHashTreeRoot) external {
-        // The sender must be a registered preconfer in the AVS registry
-        if (registryCoordinator.getOperatorStatus(msg.sender) != IRegistryCoordinator.OperatorStatus.REGISTERED) {
-            revert IPreconfTaskManager.SenderNotRegisteredInAVS();
-        } else if (consensusBLSPubKeyHashTreeRoots[msg.sender] != bytes32(0)) {
-            // The hash tree root must not be already registered
-            revert IPreconfTaskManager.SenderNotRegisteredInAVS();
-        }
-
-        consensusBLSPubKeyHashTreeRoots[msg.sender] = consensusBLSPubKeyHashTreeRoot;
-    }
-
     //=========
     // Helpers
     //=========
 
+    /// @dev Updates the lookahead for the next epoch
     function _updateLookahead(
         uint256 epochTimestamp,
         IPreconfTaskManager.LookaheadSetParam[] calldata lookaheadSetParams
@@ -336,13 +294,16 @@ contract PreconfTaskManager is IPreconfTaskManager, Initializable {
             address preconfer = lookaheadSetParams[i].preconfer;
             uint256 slotTimestamp = lookaheadSetParams[i].timestamp;
 
-            // Each entry must be a registered AVS operator
-            if (registryCoordinator.getOperatorStatus(preconfer) != IRegistryCoordinator.OperatorStatus.REGISTERED) {
-                revert IPreconfTaskManager.EntryNotRegisteredInAVS();
+            // Each entry must be registered in the preconf registry
+            if (preconfRegistry.getPreconferIndex(preconfer) != 0) {
+                revert IPreconfTaskManager.PreconferNotRegistered();
             }
 
             // Ensure that the timestamps belong to a valid slot in the next epoch
-            if ((slotTimestamp - nextEpochTimestamp) % 12 != 0 || slotTimestamp >= nextEpochEndTimestamp) {
+            if (
+                (slotTimestamp - nextEpochTimestamp) % 12 != 0 || slotTimestamp >= nextEpochEndTimestamp
+                    || slotTimestamp <= prevSlotTimestamp
+            ) {
                 revert IPreconfTaskManager.InvalidSlotTimestamp();
             }
 
@@ -397,12 +358,8 @@ contract PreconfTaskManager is IPreconfTaskManager, Initializable {
 
     function getFallbackPreconfer() public view returns (address) {
         uint256 randomness = block.prevrandao;
-        // For the POC we only have one quorum at the 0th id. If there are multiple quorums in productions
-        // we may also need to randomise the quorum selection.
-        uint8 quorumNumber = 0;
-        uint32 operatorIndex = uint32(randomness % indexRegistry.totalOperatorsForQuorum(quorumNumber));
-        bytes32 operatorId = bytes32(indexRegistry.getLatestOperatorUpdate(quorumNumber, operatorIndex).operatorId);
-        return registryCoordinator.getOperatorFromId(operatorId);
+        uint256 preconferIndex = randomness % preconfRegistry.getNextPreconferIndex();
+        return preconfRegistry.getPreconferAtIndex(preconferIndex);
     }
 
     function isLookaheadRequired(uint256 epochTimestamp) public view returns (bool) {

--- a/SmartContracts/src/interfaces/IPreconfTaskManager.sol
+++ b/SmartContracts/src/interfaces/IPreconfTaskManager.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.25;
 
+import {EIP4788} from "../libraries/EIP4788.sol";
+
 interface IPreconfTaskManager {
     struct ProposedBlock {
         // Proposer of the L2 block
@@ -47,10 +49,8 @@ interface IPreconfTaskManager {
     error InvalidLookaheadPointer();
     /// @dev The block proposer is not the assigned preconfer for the current slot/timestamp
     error SenderIsNotThePreconfer();
-    /// @dev The preconfer in the lookahead set params is not registered in the AVS
-    error EntryNotRegisteredInAVS();
-    /// @dev The sender is not registered in the AVS
-    error SenderNotRegisteredInAVS();
+    /// @dev Preconfer is not present in the registry
+    error PreconferNotRegistered();
     /// @dev The timestamp in the lookahead is not of a valid future slot in the present epoch
     error InvalidSlotTimestamp();
     /// @dev The chain id on which the preconfirmation was signed is different from the current chain's id
@@ -59,26 +59,12 @@ interface IPreconfTaskManager {
     error MissedDisputeWindow();
     /// @dev The disputed preconfirmation is correct
     error PreconfirmationIsCorrect();
-    /// @dev The preconfer is yet to register the hash tree root of their consensus BLS pub key
-    error ConsensusBLSPubKeyHashTreeRootNotRegistered();
-    /// @dev The preconfer has already registered the hash tree root of their consensus BLS pub key
-    error ConsensusBLSPubKeyHashTreeRootAlreadyRegistered();
     /// @dev The expected validator has been slashed on CL
     error ExpectedValidatorMustNotBeSlashed();
     /// @dev The lookahead poster for the epoch has already been slashed
     error PosterAlreadySlashedForTheEpoch();
-    /// @dev The registered hash tree root of preconfer's consensus BLS pub key does not match with expected validator
-    error ExpectedValidatorIsIncorrect();
-    /// @dev The validator list indices for both expected and actual validators are same
-    error ExpectedAndActualValidatorAreSame();
-    /// @dev The proof that the expected validator is a part of the validator list is invalid.
-    error ValidatorProofFailed();
-    /// @dev The proof that the validator list is a part of the beacon state is invalid.
-    error BeaconStateProofFailed();
-    /// @dev The proof that the beacon state is a part of the beacon block is invalid.
-    error BeaconBlockProofForStateFailed();
-    /// @dev The proof that the actual validator index is a part of the beacon is invalid.
-    error BeaconBlockProofForProposerIndex();
+    /// @dev The lookahead preconfer matches the one the actual validator is proposing for
+    error LookaheadEntryIsCorrect();
 
     /// @dev Accepts block proposal by an operator and forwards it to TaikoL1 contract
     function newBlockProposal(
@@ -95,20 +81,11 @@ interface IPreconfTaskManager {
     function proveIncorrectLookahead(
         uint256 lookaheadPointer,
         uint256 slotTimestamp,
-        bytes32[8] memory expectedValidator,
-        uint256 expectedValidatorIndex,
-        bytes32[] memory expectedValidatorProof,
-        uint256 actualValidatorIndex,
-        bytes32 validatorsRoot,
-        uint256 nr_validators,
-        bytes32[] memory beaconStateProof,
-        bytes32 beaconStateRoot,
-        bytes32[] memory beaconBlockProofForState,
-        bytes32[] memory beaconBlockProofForProposerIndex
+        bytes memory validatorBLSPubKey,
+        EIP4788.InclusionProof memory validatorInclusionProof
     ) external;
 
-    /// @dev Records the hash tree root of the BLS pub key that the preconfer uses on the consensus layer
-    function registerConsensusBLSPubKeyHashTreeRoot(bytes32 consensusBLSPubKeyHashTreeRoot) external;
-
+    /// @dev Returns true is a lookahead is not posted for an epoch
+    /// @dev In the event that a lookahead was posted but later invalidated, this returns false
     function isLookaheadRequired(uint256 epochTimestamp) external view returns (bool);
 }

--- a/SmartContracts/src/libraries/EIP4788.sol
+++ b/SmartContracts/src/libraries/EIP4788.sol
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.25;
+
+import {MerkleUtils} from "./MerkleUtils.sol";
+
+library EIP4788 {
+    struct InclusionProof {
+        // `Chunks` of the SSZ encoded validator
+        bytes32[8] validator;
+        // Index of the validator in the beacon state validator list
+        uint256 validatorIndex;
+        // Proof of inclusion of validator in beacon state validator list
+        bytes32[] validatorProof;
+        // Root of the validator list in the beacon state
+        bytes32 validatorsRoot;
+        // Number of validators in the validator list
+        uint256 nr_validators;
+        // Proof of inclusion of validator list in the beacon state
+        bytes32[] beaconStateProof;
+        // Root of the beacon state
+        bytes32 beaconStateRoot;
+        // Proof of inclusion of beacon state in the beacon block
+        bytes32[] beaconBlockProofForState;
+        // Proof of inclusion of the validator index in the beacon block
+        bytes32[] beaconBlockProofForProposerIndex;
+    }
+
+    /// @dev The validator pub key failed verification against the pub key hash tree root in the validator chunks
+    error InvalidValidatorBLSPubKey();
+    /// @dev The proof that the validator is a part of the validator list is invalid.
+    error ValidatorProofFailed();
+    /// @dev The proof that the validator list is a part of the beacon state is invalid.
+    error BeaconStateProofFailed();
+    /// @dev The proof that the beacon state is a part of the beacon block is invalid.
+    error BeaconBlockProofForStateFailed();
+    /// @dev The proof that the actual validator index is a part of the beacon is invalid.
+    error BeaconBlockProofForProposerIndex();
+
+    function verifyValidator(
+        bytes memory validatorBLSPubKey,
+        bytes32 beaconBlockRoot,
+        InclusionProof memory inclusionProof
+    ) internal pure {
+        // Validator's BLS public key is verified against the hash tree root within Validator chunks
+        bytes32 pubKeyHashTreeRoot = sha256(abi.encodePacked(validatorBLSPubKey, bytes16(0)));
+        if (pubKeyHashTreeRoot != inclusionProof.validator[0]) {
+            revert InvalidValidatorBLSPubKey();
+        }
+
+        // Validator is verified against the validator list in the beacon state
+        bytes32 validatorHashTreeRoot = MerkleUtils.merkleize(inclusionProof.validator);
+        if (
+            !MerkleUtils.verifyProof(
+                inclusionProof.validatorProof,
+                inclusionProof.validatorsRoot,
+                validatorHashTreeRoot,
+                inclusionProof.validatorIndex
+            )
+        ) {
+            // Revert if the proof that the expected validator is a part of the validator
+            // list in beacon state fails
+            revert ValidatorProofFailed();
+        }
+
+        // Validator list is verified against the beacon state
+        bytes32 stateValidatorsHashTreeRoot =
+            MerkleUtils.mixInLength(inclusionProof.validatorsRoot, inclusionProof.nr_validators);
+        if (
+            MerkleUtils.verifyProof(
+                inclusionProof.beaconStateProof, inclusionProof.beaconStateRoot, stateValidatorsHashTreeRoot, 11
+            )
+        ) {
+            // Revert if the proof that the validator list is a part of the beacon state fails
+            revert BeaconStateProofFailed();
+        }
+
+        // Beacon state is verified against the beacon block
+        if (
+            MerkleUtils.verifyProof(
+                inclusionProof.beaconBlockProofForState, beaconBlockRoot, inclusionProof.beaconStateRoot, 3
+            )
+        ) {
+            // Revert if the proof for the beacon state being a part of the beacon block fails
+            revert BeaconBlockProofForStateFailed();
+        }
+
+        // Validator index is verified against the beacon block
+        if (
+            MerkleUtils.verifyProof(
+                inclusionProof.beaconBlockProofForProposerIndex,
+                beaconBlockRoot,
+                MerkleUtils.toLittleEndian(inclusionProof.validatorIndex),
+                1
+            )
+        ) {
+            // Revert if the proof that the proposer index is a part of the beacon block fails
+            revert BeaconBlockProofForProposerIndex();
+        }
+    }
+}


### PR DESCRIPTION
This PR addresses #46 by integrating the new registry with the lookahead and handling disputes for cases when an empty lookahead was posted.

It also includes some refactoring, like the beacon state proof logic has been shifted to its own EIP-4788 library.