### PR TITLE
Pre testing nits

### DIFF
--- a/SmartContracts/src/avs/PreconfConstants.sol
+++ b/SmartContracts/src/avs/PreconfConstants.sol
@@ -5,6 +5,5 @@ library PreconfConstants {
     uint256 internal constant SECONDS_IN_SLOT = 12;
     uint256 internal constant SECONDS_IN_EPOCH = 384; // 32 slots * 12 seconds
     uint256 internal constant TWO_EPOCHS = 768;
-    uint256 internal constant BEACON_GENESIS_TIMESTAMP = 1606824023; // Dec-01-2020 12:00:23 PM +UTC
     uint256 internal constant DISPUTE_PERIOD = 2 * SECONDS_IN_EPOCH;
 }

--- a/SmartContracts/src/avs/PreconfTaskManager.sol
+++ b/SmartContracts/src/avs/PreconfTaskManager.sol
@@ -18,6 +18,7 @@ contract PreconfTaskManager is IPreconfTaskManager, Initializable {
     ITaikoL1 internal immutable taikoL1;
 
     // EIP-4788
+    uint256 internal immutable beaconGenesis;
     address internal immutable beaconBlockRootContract;
 
     // A ring buffer of upcoming preconfers (who are also the L1 validators)
@@ -39,11 +40,13 @@ contract PreconfTaskManager is IPreconfTaskManager, Initializable {
         IPreconfServiceManager _serviceManager,
         IPreconfRegistry _registry,
         ITaikoL1 _taikoL1,
+        uint256 _beaconGenesis,
         address _beaconBlockRootContract
     ) {
         preconfServiceManager = _serviceManager;
         preconfRegistry = _registry;
         taikoL1 = _taikoL1;
+        beaconGenesis = _beaconGenesis;
         beaconBlockRootContract = _beaconBlockRootContract;
     }
 
@@ -316,11 +319,11 @@ contract PreconfTaskManager is IPreconfTaskManager, Initializable {
     /**
      * @notice Computes the timestamp of the epoch containing the provided slot timestamp
      */
-    function _getEpochTimestamp(uint256 slotTimestamp) private pure returns (uint256) {
-        uint256 timePassedSinceGenesis = slotTimestamp - PreconfConstants.BEACON_GENESIS_TIMESTAMP;
+    function _getEpochTimestamp(uint256 slotTimestamp) private view returns (uint256) {
+        uint256 timePassedSinceGenesis = slotTimestamp - beaconGenesis;
         uint256 timeToCurrentEpochFromGenesis =
             (timePassedSinceGenesis / PreconfConstants.SECONDS_IN_EPOCH) * PreconfConstants.SECONDS_IN_EPOCH;
-        return PreconfConstants.BEACON_GENESIS_TIMESTAMP + timeToCurrentEpochFromGenesis;
+        return beaconGenesis + timeToCurrentEpochFromGenesis;
     }
 
     /**

--- a/SmartContracts/src/libraries/MerkleUtils.sol
+++ b/SmartContracts/src/libraries/MerkleUtils.sol
@@ -56,7 +56,7 @@ library MerkleUtils {
         return h == root;
     }
 
-    function toLittleEndian(uint256 n) public pure returns (bytes32) {
+    function toLittleEndian(uint256 n) internal pure returns (bytes32) {
         uint256 v = n;
         v = ((v & 0xFF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00) >> 8)
             | ((v & 0x00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF) << 8);
@@ -70,7 +70,7 @@ library MerkleUtils {
         return bytes32(v);
     }
 
-    function mixInLength(bytes32 root, uint256 length) public pure returns (bytes32) {
+    function mixInLength(bytes32 root, uint256 length) internal pure returns (bytes32) {
         bytes32 littleEndianLength = toLittleEndian(length);
         return sha256(abi.encodePacked(root, littleEndianLength));
     }


### PR DESCRIPTION
- Beacon genesis timestamp is not set at deployment so the contracts can be deployed to various networks.
- All merkle utils functions are internalised.