### PR TITLE
Remove eigenlayer middleware calls

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "SmartContracts/lib/forge-std"]
 	path = SmartContracts/lib/forge-std
 	url = https://github.com/foundry-rs/forge-std
-[submodule "SmartContracts/lib/eigenlayer-middleware"]
-	path = SmartContracts/lib/eigenlayer-middleware
-	url = https://github.com/Layr-Labs/eigenlayer-middleware
 [submodule "SmartContracts/lib/openzeppelin-contracts-upgradeable"]
 	path = SmartContracts/lib/openzeppelin-contracts-upgradeable
 	url = https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable

--- a/SmartContracts/remappings.txt
+++ b/SmartContracts/remappings.txt
@@ -1,4 +1,3 @@
-eigenlayer-middleware/=lib/eigenlayer-middleware/src
 forge-std/=lib/forge-std/src/
 openzeppelin-contracts-upgradeable/=lib/openzeppelin-contracts-upgradeable/contracts
 openzeppelin-contracts/=lib/openzeppelin-contracts/contracts

--- a/SmartContracts/src/avs/PreconfRegistry.sol
+++ b/SmartContracts/src/avs/PreconfRegistry.sol
@@ -5,13 +5,13 @@ import {BLS12381} from "../libraries/BLS12381.sol";
 import {PreconfConstants} from "./PreconfConstants.sol";
 import {BLSSignatureChecker} from "./utils/BLSSignatureChecker.sol";
 import {IPreconfRegistry} from "../interfaces/IPreconfRegistry.sol";
-import {IServiceManager} from "eigenlayer-middleware/interfaces/IServiceManager.sol";
-import {ISignatureUtils} from "eigenlayer-middleware/interfaces/IServiceManagerUI.sol";
+import {IPreconfServiceManager} from "../interfaces/IPreconfServiceManager.sol";
+import {IAVSDirectory} from "../interfaces/eigenlayer-mvp/IAVSDirectory.sol";
 
-contract PreconfRegistry is IPreconfRegistry, ISignatureUtils, BLSSignatureChecker {
+contract PreconfRegistry is IPreconfRegistry, BLSSignatureChecker {
     using BLS12381 for BLS12381.G1Point;
 
-    IServiceManager internal immutable preconfServiceManager;
+    IPreconfServiceManager internal immutable preconfServiceManager;
 
     uint256 internal nextPreconferIndex;
 
@@ -27,7 +27,7 @@ contract PreconfRegistry is IPreconfRegistry, ISignatureUtils, BLSSignatureCheck
     // Maps a validator's BLS pub key hash to the validator's details
     mapping(bytes32 publicKeyHash => Validator) internal validators;
 
-    constructor(IServiceManager _preconfServiceManager) {
+    constructor(IPreconfServiceManager _preconfServiceManager) {
         preconfServiceManager = _preconfServiceManager;
         nextPreconferIndex = 1;
     }
@@ -37,7 +37,7 @@ contract PreconfRegistry is IPreconfRegistry, ISignatureUtils, BLSSignatureCheck
      * @dev This function internally accesses Eigenlayer via the AVS service manager
      * @param operatorSignature The signature of the operator in the format expected by Eigenlayer
      */
-    function registerPreconfer(SignatureWithSaltAndExpiry calldata operatorSignature) external {
+    function registerPreconfer(IAVSDirectory.SignatureWithSaltAndExpiry calldata operatorSignature) external {
         // Preconfer must not have registered already
         if (preconferToIndex[msg.sender] != 0) {
             revert PreconferAlreadyRegistered();

--- a/SmartContracts/src/avs/PreconfServiceManager.sol
+++ b/SmartContracts/src/avs/PreconfServiceManager.sol
@@ -4,47 +4,66 @@ pragma solidity 0.8.25;
 import {IPreconfServiceManager} from "../interfaces/IPreconfServiceManager.sol";
 import {IPreconfTaskManager} from "../interfaces/IPreconfTaskManager.sol";
 import {ISlasher} from "../interfaces/eigenlayer-mvp/ISlasher.sol";
-import {
-    IAVSDirectory,
-    IRegistryCoordinator,
-    IRewardsCoordinator,
-    IStakeRegistry,
-    ServiceManagerBase
-} from "eigenlayer-middleware/ServiceManagerBase.sol";
+import {IAVSDirectory} from "../interfaces/eigenlayer-mvp/IAVSDirectory.sol";
 
-contract PreconfServiceManager is ServiceManagerBase, IPreconfServiceManager {
+contract PreconfServiceManager is IPreconfServiceManager {
+    address internal immutable preconfRegistry;
+    IAVSDirectory internal immutable avsDirectory;
     IPreconfTaskManager internal immutable preconfTaskManager;
     ISlasher internal immutable slasher;
 
     mapping(address operator => uint256 timestamp) public stakeLockedUntil;
 
     constructor(
+        address _preconfRegistry,
         IAVSDirectory _avsDirectory,
-        IRewardsCoordinator _rewardsCoordinator,
-        IRegistryCoordinator _registryCoordinator,
-        IStakeRegistry _stakeRegistry,
         IPreconfTaskManager _taskManager,
         ISlasher _slasher
-    ) ServiceManagerBase(_avsDirectory, _rewardsCoordinator, _registryCoordinator, _stakeRegistry) {
+    ) {
+        _preconfRegistry;
+        avsDirectory = _avsDirectory;
         preconfTaskManager = _taskManager;
         slasher = _slasher;
     }
 
     modifier onlyPreconfTaskManager() {
         if (msg.sender != address(preconfTaskManager)) {
-            revert SenderIsNotPreconfTaskManager(msg.sender);
+            revert SenderIsNotPreconfTaskManager();
         }
         _;
     }
 
+    modifier onlyPreconfRegistry() {
+        if (msg.sender != preconfRegistry) {
+            revert SenderIsNotPreconfRegistry();
+        }
+        _;
+    }
+
+    /// @dev Simply relays the call to the AVS directory
+    function registerOperatorToAVS(address operator, IAVSDirectory.SignatureWithSaltAndExpiry memory operatorSignature)
+        external
+        onlyPreconfRegistry
+    {
+        avsDirectory.registerOperatorToAVS(operator, operatorSignature);
+    }
+
+    /// @dev Simply relays the call to the AVS directory
+    function deregisterOperatorFromAVS(address operator) external onlyPreconfRegistry {
+        avsDirectory.deregisterOperatorFromAVS(operator);
+    }
+
+    /// @dev This not completely functional until Eigenlayer decides the logic of their Slasher.
+    ///  for now this simply sets a value in the storage and releases an event.
     function lockStakeUntil(address operator, uint256 timestamp) external onlyPreconfTaskManager {
         stakeLockedUntil[operator] = timestamp;
         emit StakeLockedUntil(operator, timestamp);
     }
 
+    /// @dev This not completely functional until Eigenlayer decides the logic of their Slasher.
     function slashOperator(address operator) external onlyPreconfTaskManager {
         if (slasher.isOperatorSlashed(operator)) {
-            revert OperatorAlreadySlashed(operator);
+            revert OperatorAlreadySlashed();
         }
         slasher.slashOperator(operator);
     }

--- a/SmartContracts/src/interfaces/IPreconfRegistry.sol
+++ b/SmartContracts/src/interfaces/IPreconfRegistry.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.25;
 
 import {BLS12381} from "../libraries/BLS12381.sol";
-import {ISignatureUtils} from "eigenlayer-middleware/interfaces/IServiceManagerUI.sol";
+import {IAVSDirectory} from "./eigenlayer-mvp/IAVSDirectory.sol";
 
 interface IPreconfRegistry {
     struct Validator {
@@ -59,7 +59,7 @@ interface IPreconfRegistry {
     error ValidatorAlreadyInactive();
 
     /// @dev Registers a preconfer by giving them a non-zero registry index
-    function registerPreconfer(ISignatureUtils.SignatureWithSaltAndExpiry calldata operatorSignature) external;
+    function registerPreconfer(IAVSDirectory.SignatureWithSaltAndExpiry calldata operatorSignature) external;
 
     /// @dev Deregisters a preconfer from the registry
     function deregisterPreconfer() external;

--- a/SmartContracts/src/interfaces/IPreconfServiceManager.sol
+++ b/SmartContracts/src/interfaces/IPreconfServiceManager.sol
@@ -1,13 +1,24 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.25;
 
-import {ServiceManagerBase} from "eigenlayer-middleware/ServiceManagerBase.sol";
+import {IAVSDirectory} from "./eigenlayer-mvp/IAVSDirectory.sol";
 
 interface IPreconfServiceManager {
     event StakeLockedUntil(address indexed operator, uint256 timestamp);
 
-    error SenderIsNotPreconfTaskManager(address);
-    error OperatorAlreadySlashed(address);
+    /// @dev Only callable by the task manager
+    error SenderIsNotPreconfTaskManager();
+    /// @dev Only callable by the registry
+    error SenderIsNotPreconfRegistry();
+    /// @dev The operator is already slashed
+    error OperatorAlreadySlashed();
+
+    /// @dev Only callable by the registry
+    function registerOperatorToAVS(address operator, IAVSDirectory.SignatureWithSaltAndExpiry memory operatorSignature)
+        external;
+
+    /// @dev Only callable by the registry
+    function deregisterOperatorFromAVS(address operator) external;
 
     /// @dev Called by PreconfTaskManager to prevent withdrawals of stake during preconf or lookahead dispute period
     function lockStakeUntil(address operator, uint256 timestamp) external;


### PR DESCRIPTION
This PR removes the use of eigenlayer middleware contracts since they bring about the need for far too many unnecessary transactions for the POC. For example - Setting up of a "quorum" and a BN254 BLS based registration.