### PR TITLE
feat: update ITaikoL1.sol to use Taiko protocol v1.9.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,6 +7,3 @@
 [submodule "SmartContracts/lib/openzeppelin-contracts"]
 	path = SmartContracts/lib/openzeppelin-contracts
 	url = https://github.com/OpenZeppelin/openzeppelin-contracts
-[submodule "SmartContracts/lib/taiko-protocol"]
-	path = SmartContracts/lib/taiko-protocol
-	url = https://github.com/taikoxyz/taiko-mono

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "SmartContracts/lib/openzeppelin-contracts"]
 	path = SmartContracts/lib/openzeppelin-contracts
 	url = https://github.com/OpenZeppelin/openzeppelin-contracts
+[submodule "SmartContracts/lib/taiko-protocol"]
+	path = SmartContracts/lib/taiko-protocol
+	url = https://github.com/taikoxyz/taiko-mono

--- a/SmartContracts/src/avs/PreconfTaskManager.sol
+++ b/SmartContracts/src/avs/PreconfTaskManager.sol
@@ -73,7 +73,7 @@ contract PreconfTaskManager is IPreconfTaskManager, Initializable {
         bytes calldata txList,
         uint256 lookaheadPointer,
         LookaheadSetParam[] calldata lookaheadSetParams
-    ) external payable {
+    ) external {
         LookaheadBufferEntry memory lookaheadEntry = lookahead[lookaheadPointer % LOOKAHEAD_BUFFER_SIZE];
 
         uint256 epochTimestamp = _getEpochTimestamp(block.timestamp);
@@ -108,7 +108,7 @@ contract PreconfTaskManager is IPreconfTaskManager, Initializable {
         preconfServiceManager.lockStakeUntil(msg.sender, block.timestamp + PreconfConstants.DISPUTE_PERIOD);
 
         // Forward the block to Taiko's L1 contract
-        taikoL1.proposeBlock{value: msg.value}(blockParams, txList);
+        taikoL1.proposeBlockV2(blockParams, txList);
     }
 
     /**
@@ -120,7 +120,7 @@ contract PreconfTaskManager is IPreconfTaskManager, Initializable {
      * @param signature The signature of the preconfirmation
      */
     function proveIncorrectPreconfirmation(
-        ITaikoL1.BlockMetadata calldata taikoBlockMetadata,
+        ITaikoL1.BlockMetadataV2 calldata taikoBlockMetadata,
         PreconfirmationHeader calldata header,
         bytes calldata signature
     ) external {
@@ -128,7 +128,7 @@ contract PreconfTaskManager is IPreconfTaskManager, Initializable {
         address proposer = blockIdToProposer[blockId];
 
         // Pull the formalised block from Taiko
-        ITaikoL1.Block memory taikoBlock = taikoL1.getBlock(uint64(blockId));
+        ITaikoL1.BlockV2 memory taikoBlock = taikoL1.getBlockV2(uint64(blockId));
 
         if (block.timestamp - taikoBlock.proposedAt >= PreconfConstants.DISPUTE_PERIOD) {
             // Revert if the dispute window has been missed

--- a/SmartContracts/src/interfaces/IPreconfTaskManager.sol
+++ b/SmartContracts/src/interfaces/IPreconfTaskManager.sol
@@ -76,11 +76,11 @@ interface IPreconfTaskManager {
         bytes calldata txList,
         uint256 lookaheadPointer,
         LookaheadSetParam[] calldata lookaheadSetParams
-    ) external payable;
+    ) external;
 
     /// @dev Slashes a preconfer if the txn and ordering in a signed preconf does not match the actual block
     function proveIncorrectPreconfirmation(
-        ITaikoL1.BlockMetadata calldata taikoBlockMetadata,
+        ITaikoL1.BlockMetadataV2 calldata taikoBlockMetadata,
         PreconfirmationHeader calldata header,
         bytes calldata signature
     ) external;

--- a/SmartContracts/src/interfaces/taiko/ITaikoL1.sol
+++ b/SmartContracts/src/interfaces/taiko/ITaikoL1.sol
@@ -1,37 +1,48 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.25;
 
+/// @dev Manual copy of lib/taiko-mono/packages/protocol/contracts/L1/TaikoL1.sol and its dependent structs
+/// from https://github.com/taikoxyz/taiko-mono/tree/protocol-v1.9.0.
 interface ITaikoL1 {
-    struct BlockMetadata {
-        bytes32 l1Hash;
+    /// @dev Struct that represents L2 basefee configurations
+    struct BaseFeeConfig {
+        uint8 adjustmentQuotient;
+        uint8 sharingPctg;
+        uint32 gasIssuancePerSecond;
+        uint64 minGasExcess;
+        uint32 maxGasIssuancePerBlock;
+    }
+
+    struct BlockMetadataV2 {
+        bytes32 anchorBlockHash; // `_l1BlockHash` in TaikoL2's anchor tx.
         bytes32 difficulty;
         bytes32 blobHash;
         bytes32 extraData;
-        bytes32 depositsHash;
         address coinbase;
         uint64 id;
         uint32 gasLimit;
         uint64 timestamp;
-        uint64 l1Height;
+        uint64 anchorBlockId; // `_l1BlockId` in TaikoL2's anchor tx.
         uint16 minTier;
         bool blobUsed;
         bytes32 parentMetaHash;
-        address sender;
+        address proposer;
+        uint96 livenessBond;
+        // Time this block is proposed at, used to check proving window and cooldown window.
+        uint64 proposedAt;
+        // L1 block number, required/used by node/client.
+        uint64 proposedIn;
         uint32 blobTxListOffset;
         uint32 blobTxListLength;
-    }
-
-    struct EthDeposit {
-        address recipient;
-        uint96 amount;
-        uint64 id;
+        uint8 blobIndex;
+        BaseFeeConfig baseFeeConfig;
     }
 
     struct SlotA {
         uint64 genesisHeight;
         uint64 genesisTimestamp;
         uint64 lastSyncedBlockId;
-        uint64 lastSynecdAt; // typo!
+        uint64 lastSynecdAt; // known typo (lastSyncedAt)
     }
 
     struct SlotB {
@@ -44,25 +55,51 @@ interface ITaikoL1 {
         uint64 lastUnpausedAt;
     }
 
-    struct Block {
-        bytes32 metaHash;
-        address assignedProver;
+    /// @dev Struct containing data required for verifying a block.
+    /// 3 slots used.
+    struct BlockV2 {
+        bytes32 metaHash; // slot 1
+        address assignedProver; // slot 2
         uint96 livenessBond;
-        uint64 blockId;
+        uint64 blockId; // slot 3
+        // Before the fork, this field is the L1 timestamp when this block is proposed.
+        // After the fork, this is the timestamp of the L2 block.
+        // In a later fork, we an rename this field to `timestamp`.
         uint64 proposedAt;
+        // This is the L1 block number input for the anchor transaction.
+        // In a later fork, we can rename this field to `anchorBlockId`.
         uint64 proposedIn;
-        uint32 nextTransitionId;
-        uint32 verifiedTransitionId;
-        uint64 timestamp;
-        uint32 l1StateBlockNumber;
+        uint24 nextTransitionId;
+        bool livenessBondReturned;
+        // The ID of the transaction that is used to verify this block. However, if this block is
+        // not verified as the last block in a batch, verifiedTransitionId will remain zero.
+        uint24 verifiedTransitionId;
     }
 
-    function proposeBlock(bytes calldata _params, bytes calldata _txList)
+    /// @notice Proposes a Taiko L2 block (version 2)
+    /// @param _params Block parameters, an encoded BlockParamsV2 object.
+    /// @param _txList txList data if calldata is used for DA.
+    /// @return meta_ The metadata of the proposed L2 block.
+    function proposeBlockV2(bytes calldata _params, bytes calldata _txList)
         external
-        payable
-        returns (BlockMetadata memory meta_, EthDeposit[] memory deposits_);
+        returns (BlockMetadataV2 memory meta_);
 
+    /// @notice Proposes multiple Taiko L2 blocks (version 2).
+    /// @param _paramsArr List of encoded BlockParamsV2 objects.
+    /// @param _txListArr List of transaction lists.
+    /// @return metaArr_ Metadata objects of the proposed L2 blocks.
+    function proposeBlocksV2(bytes[] calldata _paramsArr, bytes[] calldata _txListArr)
+        external
+        returns (BlockMetadataV2[] memory metaArr_);
+
+    /// @notice Gets the state variables of the TaikoL1 contract.
+    /// @dev This method can be deleted once node/client stops using it.
+    /// @return State variables stored at SlotA.
+    /// @return State variables stored at SlotB.
     function getStateVariables() external view returns (SlotA memory, SlotB memory);
 
-    function getBlock(uint64 _blockId) external view returns (Block memory blk_);
+    /// @notice Gets the details of a block.
+    /// @param _blockId Index of the block.
+    /// @return blk_ The block.
+    function getBlockV2(uint64 _blockId) external view returns (BlockV2 memory blk_);
 }

--- a/SmartContracts/src/mock/MockTaikoToken.sol
+++ b/SmartContracts/src/mock/MockTaikoToken.sol
@@ -2,7 +2,6 @@
 pragma solidity 0.8.25;
 
 contract MockTaikoToken {
-
     address public lastAddr;
     uint256 public lastAmount;
 

--- a/SmartContracts/test/blocks/BlockProposing.t.sol
+++ b/SmartContracts/test/blocks/BlockProposing.t.sol
@@ -130,10 +130,7 @@ contract BlockProposing is BlocksFixtures {
         // Address 1 proposes the block
         vm.prank(addr_1);
         vm.deal(addr_1, 1 ether);
-        preconfTaskManager.newBlockProposal{value: 1 ether}("Block Params", "Txn List", 1, lookaheadSetParams);
-
-        // Verify Taiko's balance
-        vm.assertEq(address(taikoL1).balance, 1 ether);
+        preconfTaskManager.newBlockProposal("Block Params", "Txn List", 1, lookaheadSetParams);
     }
 
     function test_newBlockProposal_updatesLookaheadForNextEpoch() external {

--- a/SmartContracts/test/blocks/IncorrectPreconfirmations.t.sol
+++ b/SmartContracts/test/blocks/IncorrectPreconfirmations.t.sol
@@ -17,7 +17,8 @@ contract IncorrectPreconfirmations is BlocksFixtures {
         proposeBlock();
 
         // Sets the block metadata for block id 1 in taikoL1
-        ITaikoL1.BlockMetadata memory metadata = setupTaikoBlock(1, vm.getBlockTimestamp(), keccak256("taiko_blobhash"));
+        ITaikoL1.BlockMetadataV2 memory metadata =
+            setupTaikoBlock(1, vm.getBlockTimestamp(), keccak256("taiko_blobhash"));
 
         // Get addr_1 to sign a preconfirmation header for block id 1 with a different transaction hash
         IPreconfTaskManager.PreconfirmationHeader memory header = IPreconfTaskManager.PreconfirmationHeader({
@@ -41,7 +42,8 @@ contract IncorrectPreconfirmations is BlocksFixtures {
         proposeBlock();
 
         // Sets the block metadata for block id 1 in taikoL1
-        ITaikoL1.BlockMetadata memory metadata = setupTaikoBlock(1, vm.getBlockTimestamp(), keccak256("taiko_blobhash"));
+        ITaikoL1.BlockMetadataV2 memory metadata =
+            setupTaikoBlock(1, vm.getBlockTimestamp(), keccak256("taiko_blobhash"));
 
         // Get addr_2 to sign a preconfirmation header for block id 1
         IPreconfTaskManager.PreconfirmationHeader memory header = IPreconfTaskManager.PreconfirmationHeader({
@@ -66,7 +68,8 @@ contract IncorrectPreconfirmations is BlocksFixtures {
         proposeBlock();
 
         // Sets the block metadata for block id 1 in taikoL1
-        ITaikoL1.BlockMetadata memory metadata = setupTaikoBlock(1, vm.getBlockTimestamp(), keccak256("taiko_blobhash"));
+        ITaikoL1.BlockMetadataV2 memory metadata =
+            setupTaikoBlock(1, vm.getBlockTimestamp(), keccak256("taiko_blobhash"));
 
         // Get addr_1 to sign a preconfirmation header for block id 1
         IPreconfTaskManager.PreconfirmationHeader memory header = IPreconfTaskManager.PreconfirmationHeader({
@@ -91,7 +94,8 @@ contract IncorrectPreconfirmations is BlocksFixtures {
         proposeBlock();
 
         // Sets the block metadata for block id 1 in taikoL1
-        ITaikoL1.BlockMetadata memory metadata = setupTaikoBlock(1, vm.getBlockTimestamp(), keccak256("taiko_blobhash"));
+        ITaikoL1.BlockMetadataV2 memory metadata =
+            setupTaikoBlock(1, vm.getBlockTimestamp(), keccak256("taiko_blobhash"));
 
         // Get addr_1 to sign a preconfirmation header for block id 1 with incorrect chain ID
         IPreconfTaskManager.PreconfirmationHeader memory header = IPreconfTaskManager.PreconfirmationHeader({
@@ -113,11 +117,11 @@ contract IncorrectPreconfirmations is BlocksFixtures {
         proposeBlock();
 
         // Sets the block metadata for block id 1 in taikoL1
-        ITaikoL1.BlockMetadata memory correctMetadata =
+        ITaikoL1.BlockMetadataV2 memory correctMetadata =
             setupTaikoBlock(1, vm.getBlockTimestamp(), keccak256("taiko_blobhash"));
 
         // Create incorrect metadata
-        ITaikoL1.BlockMetadata memory incorrectMetadata = correctMetadata;
+        ITaikoL1.BlockMetadataV2 memory incorrectMetadata = correctMetadata;
         incorrectMetadata.blobHash = keccak256("incorrect_blobhash");
 
         // Get addr_1 to sign a preconfirmation header for block id 1
@@ -140,7 +144,8 @@ contract IncorrectPreconfirmations is BlocksFixtures {
         proposeBlock();
 
         // Sets the block metadata for block id 1 in taikoL1
-        ITaikoL1.BlockMetadata memory metadata = setupTaikoBlock(1, vm.getBlockTimestamp(), keccak256("taiko_blobhash"));
+        ITaikoL1.BlockMetadataV2 memory metadata =
+            setupTaikoBlock(1, vm.getBlockTimestamp(), keccak256("taiko_blobhash"));
 
         // Get addr_1 to sign a correct preconfirmation header for block id 1
         IPreconfTaskManager.PreconfirmationHeader memory header = IPreconfTaskManager.PreconfirmationHeader({
@@ -162,7 +167,8 @@ contract IncorrectPreconfirmations is BlocksFixtures {
         proposeBlock();
 
         // Sets the block metadata for block id 1 in taikoL1
-        ITaikoL1.BlockMetadata memory metadata = setupTaikoBlock(1, vm.getBlockTimestamp(), keccak256("taiko_blobhash"));
+        ITaikoL1.BlockMetadataV2 memory metadata =
+            setupTaikoBlock(1, vm.getBlockTimestamp(), keccak256("taiko_blobhash"));
 
         // Get addr_2 to sign an incorrect preconfirmation header for block id 1
         IPreconfTaskManager.PreconfirmationHeader memory header = IPreconfTaskManager.PreconfirmationHeader({

--- a/SmartContracts/test/fixtures/BlocksFixtures.sol
+++ b/SmartContracts/test/fixtures/BlocksFixtures.sol
@@ -66,9 +66,9 @@ contract BlocksFixtures is BaseTest {
 
     function setupTaikoBlock(uint256 id, uint256 proposedAt, bytes32 txListHash)
         internal
-        returns (ITaikoL1.BlockMetadata memory)
+        returns (ITaikoL1.BlockMetadataV2 memory)
     {
-        ITaikoL1.BlockMetadata memory metadata;
+        ITaikoL1.BlockMetadataV2 memory metadata;
 
         metadata.blobHash = txListHash;
         metadata.id = uint64(id);

--- a/SmartContracts/test/mocks/MockTaikoL1.sol
+++ b/SmartContracts/test/mocks/MockTaikoL1.sol
@@ -7,25 +7,28 @@ contract MockTaikoL1 is ITaikoL1 {
     bytes public params;
     bytes public txList;
     uint256 public blockId;
-    Block public blk;
+    BlockV2 public blk;
 
-    function proposeBlock(bytes calldata _params, bytes calldata _txList)
+    function proposeBlockV2(bytes calldata _params, bytes calldata _txList)
         external
-        payable
-        returns (BlockMetadata memory a, EthDeposit[] memory b)
+        returns (BlockMetadataV2 memory meta_)
     {
         params = _params;
         txList = _txList;
-
-        return (a, b);
+        return meta_;
     }
+
+    function proposeBlocksV2(bytes[] calldata _paramsArr, bytes[] calldata _txListArr)
+        external
+        returns (BlockMetadataV2[] memory)
+    {}
 
     function getStateVariables() external view returns (SlotA memory a, SlotB memory b) {
         b.numBlocks = uint64(blockId);
         return (a, b);
     }
 
-    function getBlock(uint64) external view returns (Block memory blk_) {
+    function getBlockV2(uint64) external view returns (BlockV2 memory blk_) {
         return blk;
     }
 


### PR DESCRIPTION
Updated ITaikoL1.sol to align with Taiko’s recent protocol release (v1.9.0). This release introduces support for proposing multiple blocks in a single L1 transaction using ITaiko.proposeBlocksV2. Note that this feature is currently not utilized by IPreconfTaskManager (pending further evaluation on whether it should be).