### PR TITLE
Refactor contract dependency

### DIFF
--- a/SmartContracts/scripts/deployment/DeployAVS.s.sol
+++ b/SmartContracts/scripts/deployment/DeployAVS.s.sol
@@ -39,9 +39,9 @@ contract DeployAVS is BaseScript {
         address preconfTaskManager = deployProxy(address(emptyContract), address(proxyAdmin), "");
 
         // Deploy implementations
-        PreconfRegistry preconfRegistryImpl = new PreconfRegistry(IPreconfServiceManager(preconfServiceManager));
+        PreconfRegistry preconfRegistryImpl = new PreconfRegistry(IAVSDirectory(avsDirectory));
         PreconfServiceManager preconfServiceManagerImpl = new PreconfServiceManager(
-            preconfRegistry, preconfTaskManager, IAVSDirectory(avsDirectory), ISlasher(slasher)
+            preconfTaskManager, IAVSDirectory(avsDirectory), ISlasher(slasher)
         );
         PreconfTaskManager preconfTaskManagerImpl = new PreconfTaskManager(
             IPreconfServiceManager(preconfServiceManager),

--- a/SmartContracts/src/avs/PreconfRegistry.sol
+++ b/SmartContracts/src/avs/PreconfRegistry.sol
@@ -12,7 +12,8 @@ import {Initializable} from "openzeppelin-contracts-upgradeable/proxy/utils/Init
 contract PreconfRegistry is IPreconfRegistry, BLSSignatureChecker, Initializable {
     using BLS12381 for BLS12381.G1Point;
 
-    IPreconfServiceManager internal immutable preconfServiceManager;
+    // IPreconfServiceManager internal immutable preconfServiceManager;
+    IAVSDirectory public immutable avsDirectory;
 
     uint256 internal nextPreconferIndex;
 
@@ -28,8 +29,8 @@ contract PreconfRegistry is IPreconfRegistry, BLSSignatureChecker, Initializable
     // Maps a validator's BLS pub key hash to the validator's details
     mapping(bytes32 publicKeyHash => Validator) internal validators;
 
-    constructor(IPreconfServiceManager _preconfServiceManager) {
-        preconfServiceManager = _preconfServiceManager;
+    constructor(IAVSDirectory _avsDirectory) {
+        avsDirectory = _avsDirectory;
     }
 
     function initialize() external initializer {
@@ -58,7 +59,7 @@ contract PreconfRegistry is IPreconfRegistry, BLSSignatureChecker, Initializable
 
         emit PreconferRegistered(msg.sender);
 
-        preconfServiceManager.registerOperatorToAVS(msg.sender, operatorSignature);
+        avsDirectory.registerOperatorToAVS(msg.sender, operatorSignature);
     }
 
     /**
@@ -89,7 +90,7 @@ contract PreconfRegistry is IPreconfRegistry, BLSSignatureChecker, Initializable
 
         emit PreconferDeregistered(msg.sender);
 
-        preconfServiceManager.deregisterOperatorFromAVS(msg.sender);
+        avsDirectory.deregisterOperatorFromAVS(msg.sender);
     }
 
     /**

--- a/SmartContracts/src/avs/PreconfRegistry.sol
+++ b/SmartContracts/src/avs/PreconfRegistry.sol
@@ -13,7 +13,7 @@ contract PreconfRegistry is IPreconfRegistry, BLSSignatureChecker, Initializable
     using BLS12381 for BLS12381.G1Point;
 
     // IPreconfServiceManager internal immutable preconfServiceManager;
-    IAVSDirectory public immutable avsDirectory;
+    IAVSDirectory internal immutable avsDirectory;
 
     uint256 internal nextPreconferIndex;
 

--- a/SmartContracts/src/avs/PreconfServiceManager.sol
+++ b/SmartContracts/src/avs/PreconfServiceManager.sol
@@ -11,7 +11,6 @@ import {IAVSDirectory} from "../interfaces/eigenlayer-mvp/IAVSDirectory.sol";
  * This contract may be modified depending on the interface of the restaking contracts.
  */
 contract PreconfServiceManager is IPreconfServiceManager {
-    address internal immutable preconfRegistry;
     address internal immutable preconfTaskManager;
     IAVSDirectory internal immutable avsDirectory;
     ISlasher internal immutable slasher;
@@ -19,8 +18,7 @@ contract PreconfServiceManager is IPreconfServiceManager {
     /// @dev This is currently just a flag and not actually being used to lock the stake.
     mapping(address operator => uint256 timestamp) public stakeLockedUntil;
 
-    constructor(address _preconfRegistry, address _preconfTaskManager, IAVSDirectory _avsDirectory, ISlasher _slasher) {
-        preconfRegistry = _preconfRegistry;
+    constructor(address _preconfTaskManager, IAVSDirectory _avsDirectory, ISlasher _slasher) {
         preconfTaskManager = _preconfTaskManager;
         avsDirectory = _avsDirectory;
         slasher = _slasher;
@@ -31,26 +29,6 @@ contract PreconfServiceManager is IPreconfServiceManager {
             revert SenderIsNotPreconfTaskManager();
         }
         _;
-    }
-
-    modifier onlyPreconfRegistry() {
-        if (msg.sender != preconfRegistry) {
-            revert SenderIsNotPreconfRegistry();
-        }
-        _;
-    }
-
-    /// @dev Simply relays the call to the AVS directory
-    function registerOperatorToAVS(address operator, IAVSDirectory.SignatureWithSaltAndExpiry memory operatorSignature)
-        external
-        onlyPreconfRegistry
-    {
-        avsDirectory.registerOperatorToAVS(operator, operatorSignature);
-    }
-
-    /// @dev Simply relays the call to the AVS directory
-    function deregisterOperatorFromAVS(address operator) external onlyPreconfRegistry {
-        avsDirectory.deregisterOperatorFromAVS(operator);
     }
 
     /// @dev This not completely functional until Eigenlayer decides the logic of their Slasher.

--- a/SmartContracts/src/avs/PreconfServiceManager.sol
+++ b/SmartContracts/src/avs/PreconfServiceManager.sol
@@ -25,7 +25,7 @@ contract PreconfServiceManager is IPreconfServiceManager {
     }
 
     modifier onlyPreconfTaskManager() {
-        if (msg.sender != address(preconfTaskManager)) {
+        if (msg.sender != preconfTaskManager) {
             revert SenderIsNotPreconfTaskManager();
         }
         _;

--- a/SmartContracts/src/interfaces/IPreconfRegistry.sol
+++ b/SmartContracts/src/interfaces/IPreconfRegistry.sol
@@ -6,7 +6,7 @@ import {IAVSDirectory} from "./eigenlayer-mvp/IAVSDirectory.sol";
 
 interface IPreconfRegistry {
     struct Validator {
-        // Preconfer that the validator proposer blocks for
+        // Preconfer that the validator proposes blocks for
         address preconfer;
         // Timestamp at which the preconfer may start proposing for the preconfer
         // 2 epochs from validator addition timestamp

--- a/SmartContracts/src/interfaces/IPreconfServiceManager.sol
+++ b/SmartContracts/src/interfaces/IPreconfServiceManager.sol
@@ -13,13 +13,6 @@ interface IPreconfServiceManager {
     /// @dev The operator is already slashed
     error OperatorAlreadySlashed();
 
-    /// @dev Only callable by the registry
-    function registerOperatorToAVS(address operator, IAVSDirectory.SignatureWithSaltAndExpiry memory operatorSignature)
-        external;
-
-    /// @dev Only callable by the registry
-    function deregisterOperatorFromAVS(address operator) external;
-
     /// @dev Called by PreconfTaskManager to prevent withdrawals of stake during preconf or lookahead dispute period
     function lockStakeUntil(address operator, uint256 timestamp) external;
 

--- a/SmartContracts/src/mock/MockPreconfRegistry.sol
+++ b/SmartContracts/src/mock/MockPreconfRegistry.sol
@@ -5,14 +5,13 @@ import {BLS12381} from "../libraries/BLS12381.sol";
 import {PreconfConstants} from "../avs/PreconfConstants.sol";
 import {BLSSignatureChecker} from "../avs/utils/BLSSignatureChecker.sol";
 import {IPreconfRegistry} from "../interfaces/IPreconfRegistry.sol";
-import {IPreconfServiceManager} from "../interfaces/IPreconfServiceManager.sol";
 import {IAVSDirectory} from "../interfaces/eigenlayer-mvp/IAVSDirectory.sol";
 import {Initializable} from "openzeppelin-contracts-upgradeable/proxy/utils/Initializable.sol";
 
 contract MockPreconfRegistry is IPreconfRegistry, BLSSignatureChecker, Initializable {
     using BLS12381 for BLS12381.G1Point;
 
-    IPreconfServiceManager internal immutable preconfServiceManager;
+    IAVSDirectory internal immutable avsDirectory;
 
     uint256 internal nextPreconferIndex;
 
@@ -28,8 +27,8 @@ contract MockPreconfRegistry is IPreconfRegistry, BLSSignatureChecker, Initializ
     // Maps a validator's BLS pub key hash to the validator's details
     mapping(bytes32 publicKeyHash => Validator) internal validators;
 
-    constructor(IPreconfServiceManager _preconfServiceManager) {
-        preconfServiceManager = _preconfServiceManager;
+    constructor(IAVSDirectory _avsDirectory) {
+        avsDirectory = _avsDirectory;
     }
 
     function initialize() external initializer {
@@ -58,7 +57,7 @@ contract MockPreconfRegistry is IPreconfRegistry, BLSSignatureChecker, Initializ
 
         emit PreconferRegistered(msg.sender);
 
-        preconfServiceManager.registerOperatorToAVS(msg.sender, operatorSignature);
+        avsDirectory.registerOperatorToAVS(msg.sender, operatorSignature);
     }
 
     /**
@@ -89,7 +88,7 @@ contract MockPreconfRegistry is IPreconfRegistry, BLSSignatureChecker, Initializ
 
         emit PreconferDeregistered(msg.sender);
 
-        preconfServiceManager.deregisterOperatorFromAVS(msg.sender);
+        avsDirectory.deregisterOperatorFromAVS(msg.sender);
     }
 
     /**

--- a/SmartContracts/src/mock/MockTaikoToken.sol
+++ b/SmartContracts/src/mock/MockTaikoToken.sol
@@ -2,7 +2,6 @@
 pragma solidity 0.8.25;
 
 contract MockTaikoToken {
-
     address public lastAddr;
     uint256 public lastAmount;
 


### PR DESCRIPTION
I found there are some unnecessary dependencies among `PreconfRegistry`, `PreconfServiceManager`, and `PreconfTaskManager`. This PR is try to refacor away some of these dependencies. 

If this PR makes sense, then `PreconfServiceManager` now only has two functions that are only callable by the `PreconfTaskManager`, is it a good idea to merge `PreconfServiceManager` into `PreconfTaskManager`?