### PR TITLE
PreconfServiceManager: slightly simplify modifiers and make immutable public

### DIFF
--- a/SmartContracts/src/interfaces/IPreconfServiceManager.sol
+++ b/SmartContracts/src/interfaces/IPreconfServiceManager.sol
@@ -6,10 +6,8 @@ import {IAVSDirectory} from "./eigenlayer-mvp/IAVSDirectory.sol";
 interface IPreconfServiceManager {
     event StakeLockedUntil(address indexed operator, uint256 timestamp);
 
-    /// @dev Only callable by the task manager
-    error SenderIsNotPreconfTaskManager();
-    /// @dev Only callable by the registry
-    error SenderIsNotPreconfRegistry();
+    /// @dev Only callable by a given
+    error SenderIsNotAllowed();
     /// @dev The operator is already slashed
     error OperatorAlreadySlashed();
 
@@ -20,9 +18,9 @@ interface IPreconfServiceManager {
     /// @dev Only callable by the registry
     function deregisterOperatorFromAVS(address operator) external;
 
-    /// @dev Called by PreconfTaskManager to prevent withdrawals of stake during preconf or lookahead dispute period
+    /// @dev Only callable by PreconfTaskManager to prevent withdrawals of stake during preconf or lookahead dispute period
     function lockStakeUntil(address operator, uint256 timestamp) external;
 
-    /// @dev Called by PreconfTaskManager to slash an operator for incorret lookahead or preconfirmation
+    /// @dev Only callable by PreconfTaskManager to slash an operator for incorret lookahead or preconfirmation
     function slashOperator(address operator) external;
 }


### PR DESCRIPTION
I think it may be necessary to make the immutable public so we can know what values are being used.