### PR TITLE
Reserve 200 slots for 3 contracts

### DIFF
--- a/SmartContracts/src/avs/PreconfRegistry.sol
+++ b/SmartContracts/src/avs/PreconfRegistry.sol
@@ -28,6 +28,8 @@ contract PreconfRegistry is IPreconfRegistry, BLSSignatureChecker, Initializable
     // Maps a validator's BLS pub key hash to the validator's details
     mapping(bytes32 publicKeyHash => Validator) internal validators;
 
+    uint256[196] private __gap; // = 200 - 4
+
     constructor(IPreconfServiceManager _preconfServiceManager) {
         preconfServiceManager = _preconfServiceManager;
     }

--- a/SmartContracts/src/avs/PreconfServiceManager.sol
+++ b/SmartContracts/src/avs/PreconfServiceManager.sol
@@ -18,6 +18,7 @@ contract PreconfServiceManager is IPreconfServiceManager {
 
     /// @dev This is currently just a flag and not actually being used to lock the stake.
     mapping(address operator => uint256 timestamp) public stakeLockedUntil;
+    uint256[199] private __gap; // 200 - 1
 
     constructor(address _preconfRegistry, address _preconfTaskManager, IAVSDirectory _avsDirectory, ISlasher _slasher) {
         preconfRegistry = _preconfRegistry;

--- a/SmartContracts/src/avs/PreconfTaskManager.sol
+++ b/SmartContracts/src/avs/PreconfTaskManager.sol
@@ -16,13 +16,19 @@ contract PreconfTaskManager is IPreconfTaskManager, Initializable {
     IPreconfRegistry internal immutable preconfRegistry;
     ITaikoL1 internal immutable taikoL1;
 
+    // Cannot be kept in `PreconfConstants` file because solidity expects array sizes
+    // to be stored in the main contract file itself.
+    uint256 internal constant SLOTS_IN_EPOCH = 32;
+    uint256 internal constant LOOKAHEAD_BUFFER_SIZE = 64;
+
     // EIP-4788
     uint256 internal immutable beaconGenesis;
     address internal immutable beaconBlockRootContract;
 
     // A ring buffer of upcoming preconfers (who are also the L1 validators)
     uint256 internal lookaheadTail;
-    uint256 internal constant LOOKAHEAD_BUFFER_SIZE = 64;
+
+    // Since LookaheadBufferEntry uses 1 slot, the fix-size array below uses 64 slots.
     LookaheadBufferEntry[LOOKAHEAD_BUFFER_SIZE] internal lookahead;
 
     // Maps the epoch timestamp to the lookahead poster.
@@ -34,9 +40,7 @@ contract PreconfTaskManager is IPreconfTaskManager, Initializable {
     // This is required since the stored block in Taiko has the address of this contract as the proposer
     mapping(uint256 blockId => address proposer) internal blockIdToProposer;
 
-    // Cannot be kept in `PreconfConstants` file because solidity expects array sizes
-    // to be stored in the main contract file itself.
-    uint256 internal constant SLOTS_IN_EPOCH = 32;
+    uint256[133] private __gap; // = 200 - 67
 
     constructor(
         IPreconfServiceManager _serviceManager,

--- a/SmartContracts/src/avs/PreconfTaskManager.sol
+++ b/SmartContracts/src/avs/PreconfTaskManager.sol
@@ -16,19 +16,13 @@ contract PreconfTaskManager is IPreconfTaskManager, Initializable {
     IPreconfRegistry internal immutable preconfRegistry;
     ITaikoL1 internal immutable taikoL1;
 
-    // Cannot be kept in `PreconfConstants` file because solidity expects array sizes
-    // to be stored in the main contract file itself.
-    uint256 internal constant SLOTS_IN_EPOCH = 32;
-    uint256 internal constant LOOKAHEAD_BUFFER_SIZE = 64;
-
     // EIP-4788
     uint256 internal immutable beaconGenesis;
     address internal immutable beaconBlockRootContract;
 
     // A ring buffer of upcoming preconfers (who are also the L1 validators)
     uint256 internal lookaheadTail;
-
-    // Since LookaheadBufferEntry uses 1 slot, the fix-size array below uses 64 slots.
+    uint256 internal constant LOOKAHEAD_BUFFER_SIZE = 64;
     LookaheadBufferEntry[LOOKAHEAD_BUFFER_SIZE] internal lookahead;
 
     // Maps the epoch timestamp to the lookahead poster.
@@ -39,6 +33,11 @@ contract PreconfTaskManager is IPreconfTaskManager, Initializable {
     // Maps the block height to the associated proposer
     // This is required since the stored block in Taiko has the address of this contract as the proposer
     mapping(uint256 blockId => address proposer) internal blockIdToProposer;
+
+    // Cannot be kept in `PreconfConstants` file because solidity expects array sizes
+    // to be stored in the main contract file itself.
+    uint256 internal constant SLOTS_IN_EPOCH = 32;
+
 
     uint256[133] private __gap; // = 200 - 67
 

--- a/SmartContracts/src/avs/PreconfTaskManager.sol
+++ b/SmartContracts/src/avs/PreconfTaskManager.sol
@@ -38,7 +38,6 @@ contract PreconfTaskManager is IPreconfTaskManager, Initializable {
     // to be stored in the main contract file itself.
     uint256 internal constant SLOTS_IN_EPOCH = 32;
 
-
     uint256[133] private __gap; // = 200 - 67
 
     constructor(


### PR DESCRIPTION
Since these three contracts are upgradeable via proxies, it's important to prevent unintended storage collisions . To avoid this, maybe we can learn from OpenZeppelin to establish a fixed storage boundary for these contracts.