### PR TITLE
allow any address to call `addValidators`

### DIFF
--- a/SmartContracts/src/avs/PreconfRegistry.sol
+++ b/SmartContracts/src/avs/PreconfRegistry.sol
@@ -139,7 +139,7 @@ contract PreconfRegistry is IPreconfRegistry, BLSSignatureChecker, Initializable
             ) {
                 unchecked {
                     validators[pubKeyHash] = Validator({
-                        preconfer: msg.sender,
+                        preconfer: addValidatorParams[i].preconfer,
                         // The delay is crucial in order to not contradict the lookahead
                         startProposingAt: uint40(block.timestamp + PreconfConstants.TWO_EPOCHS),
                         stopProposingAt: uint40(0)
@@ -150,7 +150,7 @@ contract PreconfRegistry is IPreconfRegistry, BLSSignatureChecker, Initializable
                 revert ValidatorAlreadyActive();
             }
 
-            emit ValidatorAdded(pubKeyHash, msg.sender);
+            emit ValidatorAdded(pubKeyHash, addValidatorParams[i].preconfer);
         }
     }
 

--- a/SmartContracts/src/interfaces/IPreconfRegistry.sol
+++ b/SmartContracts/src/interfaces/IPreconfRegistry.sol
@@ -18,6 +18,8 @@ interface IPreconfRegistry {
     // ^ Note: 40 bits are enough for UNIX timestamp. This way we also compress the data to a single slot.
 
     struct AddValidatorParam {
+        // Preconfer that the validator is added to.
+        address preconfer;
         // The public key of the validator
         BLS12381.G1Point pubkey;
         // The signature of the validator


### PR DESCRIPTION
The `addValidators` function is only callable by the preconfer for which the new validators will be added. But since the validators has already authorized this operation with a BLS signature, maybe we can allow any address to transact `addValidators`?  Or do you think adding validators should have "approvals" from both validators and the preconfer - the fact that only the preconfer can transact this function servers as another "approval".