### PR TITLE
Use mapping for `lookahead` in PreconfTaskManager.sol

### DIFF
--- a/SmartContracts/src/avs/PreconfRegistry.sol
+++ b/SmartContracts/src/avs/PreconfRegistry.sol
@@ -28,7 +28,7 @@ contract PreconfRegistry is IPreconfRegistry, BLSSignatureChecker, Initializable
     // Maps a validator's BLS pub key hash to the validator's details
     mapping(bytes32 publicKeyHash => Validator) internal validators;
 
-    uint256[196] private __gap; // = 200 - 4
+    uint256[46] private __gap; // = 50 - 4
 
     constructor(IPreconfServiceManager _preconfServiceManager) {
         preconfServiceManager = _preconfServiceManager;
@@ -74,7 +74,7 @@ contract PreconfRegistry is IPreconfRegistry, BLSSignatureChecker, Initializable
         if (removedPreconferIndex == 0) {
             revert PreconferNotRegistered();
         }
-        
+
         // Remove the preconfer and exchange its index with the last preconfer
         preconferToIndex[msg.sender] = 0;
 

--- a/SmartContracts/src/avs/PreconfServiceManager.sol
+++ b/SmartContracts/src/avs/PreconfServiceManager.sol
@@ -19,7 +19,7 @@ contract PreconfServiceManager is IPreconfServiceManager, ReentrancyGuard {
 
     /// @dev This is currently just a flag and not actually being used to lock the stake.
     mapping(address operator => uint256 timestamp) public stakeLockedUntil;
-    uint256[199] private __gap; // 200 - 1
+    uint256[49] private __gap; // 50 - 1
 
     constructor(address _preconfRegistry, address _preconfTaskManager, IAVSDirectory _avsDirectory, ISlasher _slasher) {
         preconfRegistry = _preconfRegistry;

--- a/SmartContracts/src/avs/PreconfTaskManager.sol
+++ b/SmartContracts/src/avs/PreconfTaskManager.sol
@@ -28,7 +28,7 @@ contract PreconfTaskManager is IPreconfTaskManager, Initializable {
 
     // A ring buffer of upcoming preconfers (who are also the L1 validators)
     uint256 internal lookaheadTail;
-    mapping (uint256 => LookaheadBufferEntry) internal lookahead;
+    mapping(uint256 => LookaheadBufferEntry) internal lookahead;
 
     // Maps the epoch timestamp to the lookahead poster.
     // If the lookahead poster has been slashed, it maps to the 0-address.
@@ -38,8 +38,6 @@ contract PreconfTaskManager is IPreconfTaskManager, Initializable {
     // Maps the block height to the associated proposer
     // This is required since the stored block in Taiko has the address of this contract as the proposer
     mapping(uint256 blockId => address proposer) internal blockIdToProposer;
-
-    
 
     uint256[196] private __gap; // = 200 - 4
 

--- a/SmartContracts/src/avs/PreconfTaskManager.sol
+++ b/SmartContracts/src/avs/PreconfTaskManager.sol
@@ -39,7 +39,7 @@ contract PreconfTaskManager is IPreconfTaskManager, Initializable {
     // This is required since the stored block in Taiko has the address of this contract as the proposer
     mapping(uint256 blockId => address proposer) internal blockIdToProposer;
 
-    uint256[196] private __gap; // = 200 - 4
+    uint256[46] private __gap; // = 50 - 4
 
     constructor(
         IPreconfServiceManager _serviceManager,

--- a/SmartContracts/src/mock/MockTaikoToken.sol
+++ b/SmartContracts/src/mock/MockTaikoToken.sol
@@ -2,7 +2,6 @@
 pragma solidity 0.8.25;
 
 contract MockTaikoToken {
-
     address public lastAddr;
     uint256 public lastAmount;
 


### PR DESCRIPTION
This makes state var `lookahead` use 1 slot regardless its actual size.