### PR TITLE
Propagating error of crated transaction

### DIFF
--- a/Node/Cargo.lock
+++ b/Node/Cargo.lock
@@ -5098,7 +5098,7 @@ dependencies = [
 
 [[package]]
 name = "taiko_preconf_avs_node"
-version = "0.2.36"
+version = "0.2.37"
 dependencies = [
  "alloy",
  "alloy-json-rpc",

--- a/Node/Cargo.toml
+++ b/Node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taiko_preconf_avs_node"
-version = "0.2.36"
+version = "0.2.37"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Node/src/ethereum_l1/execution_layer.rs
+++ b/Node/src/ethereum_l1/execution_layer.rs
@@ -203,10 +203,10 @@ impl ExecutionLayer {
 
         let pending_nonce = self.get_preconfer_nonce_pending().await?;
         // Spawn a monitor for this transaction
-        let _ = self
-            .transaction_monitor
+        self.transaction_monitor
             .monitor_new_transaction(tx, pending_nonce)
-            .await;
+            .await
+            .map_err(|e| Error::msg(format!("Sending batch to L1 failed: {}", e)))?;
 
         Ok(())
     }


### PR DESCRIPTION
First step to better handle txs reverts. Potential error is propagated to the main loop, the batch with failed txs is not removed from the batch vector. The batch will be resent in next iteration with submit role.