### PR TITLE
Propose batch transactions sent one by one in separate thread

### DIFF
--- a/Node/Cargo.lock
+++ b/Node/Cargo.lock
@@ -5098,7 +5098,7 @@ dependencies = [
 
 [[package]]
 name = "taiko_preconf_avs_node"
-version = "0.2.36"
+version = "0.2.37"
 dependencies = [
  "alloy",
  "alloy-json-rpc",

--- a/Node/Cargo.toml
+++ b/Node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taiko_preconf_avs_node"
-version = "0.2.36"
+version = "0.2.37"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Node/src/ethereum_l1/execution_layer.rs
+++ b/Node/src/ethereum_l1/execution_layer.rs
@@ -142,6 +142,10 @@ impl ExecutionLayer {
         Ok(operator)
     }
 
+    pub async fn is_transaction_in_progress(&self) -> Result<bool, Error> {
+        self.transaction_monitor.is_transaction_in_progress().await
+    }
+
     pub async fn send_batch_to_l1(
         &self,
         l2_blocks: Vec<L2Block>,

--- a/Node/src/ethereum_l1/execution_layer.rs
+++ b/Node/src/ethereum_l1/execution_layer.rs
@@ -203,10 +203,10 @@ impl ExecutionLayer {
 
         let pending_nonce = self.get_preconfer_nonce_pending().await?;
         // Spawn a monitor for this transaction
-        let _ = self
-            .transaction_monitor
+        self.transaction_monitor
             .monitor_new_transaction(tx, pending_nonce)
-            .await;
+            .await
+            .map_err(|e| Error::msg(format!("Sending batch to L1 failed: {}", e)))?;
 
         Ok(())
     }

--- a/Node/src/ethereum_l1/execution_layer.rs
+++ b/Node/src/ethereum_l1/execution_layer.rs
@@ -14,12 +14,13 @@ use alloy::{
 };
 use anyhow::Error;
 use std::{str::FromStr, sync::Arc};
+use tokio::sync::mpsc::Sender;
 
 use tracing::debug;
 
 use crate::ethereum_l1::propose_batch_builder::ProposeBatchBuilder;
 
-use super::config::EthereumL1Config;
+use super::{config::EthereumL1Config, transaction_error::TransactionError};
 
 pub struct ExecutionLayer {
     provider_ws: Arc<WsProvider>,
@@ -39,7 +40,10 @@ pub struct ContractAddresses {
 }
 
 impl ExecutionLayer {
-    pub async fn new(config: EthereumL1Config) -> Result<Self, Error> {
+    pub async fn new(
+        config: EthereumL1Config,
+        transaction_error_channel: Sender<TransactionError>,
+    ) -> Result<Self, Error> {
         tracing::debug!(
             "Creating ExecutionLayer with WS URL: {}",
             config.execution_ws_rpc_url
@@ -75,6 +79,7 @@ impl ExecutionLayer {
             config.tx_fees_increase_percentage,
             config.max_attempts_to_send_tx,
             config.delay_between_tx_attempts_sec,
+            transaction_error_channel,
         )
         .await?;
 
@@ -310,6 +315,8 @@ impl ExecutionLayer {
         let preconfer_address = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2" // some random address for test
             .parse()?;
 
+        let (tx_error_sender, _) = tokio::sync::mpsc::channel(1);
+
         Ok(Self {
             provider_ws: provider_ws.clone(),
             preconfer_address,
@@ -355,6 +362,7 @@ impl ExecutionLayer {
                 5,
                 4,
                 15,
+                tx_error_sender,
             )
             .await
             .unwrap(),

--- a/Node/src/ethereum_l1/monitor_transaction.rs
+++ b/Node/src/ethereum_l1/monitor_transaction.rs
@@ -125,7 +125,6 @@ impl TransactionMonitorThread {
             let pending_tx = match self.create_initial_pending_tx(tx.clone()).await {
                 Ok(tx) => tx,
                 Err(e) => {
-                    // TODO: send signal to reorg
                     error!("Failed to send transaction: {}", e);
                     self.send_error_signal(TransactionError::TransactionReverted)
                         .await;

--- a/Node/src/ethereum_l1/transaction_error.rs
+++ b/Node/src/ethereum_l1/transaction_error.rs
@@ -1,0 +1,4 @@
+pub enum TransactionError {
+    TransactionReverted,
+    NotConfirmed,
+}

--- a/Node/src/node/batch_manager/batch_builder.rs
+++ b/Node/src/node/batch_manager/batch_builder.rs
@@ -188,11 +188,11 @@ impl BatchBuilder {
             self.finalize_current_batch();
         }
 
-        if self.batches_to_send.len() > 0 {
-            debug!("Submitting {} batches", self.batches_to_send.len());
-        }
-
         if let Some(batch) = self.batches_to_send.front() {
+            debug!(
+                "Submitting batch with anchor block id: {}",
+                batch.anchor_block_id
+            );
             ethereum_l1
                 .execution_layer
                 .send_batch_to_l1(batch.l2_blocks.clone(), batch.anchor_block_id, coinbase)

--- a/Node/src/node/batch_manager/mod.rs
+++ b/Node/src/node/batch_manager/mod.rs
@@ -229,21 +229,21 @@ impl BatchManager {
         Ok(std::cmp::max(height_from_last_batch, l1_height_with_lag))
     }
 
-    pub async fn try_submit_batches(
+    pub async fn try_submit_oldest_batch(
         &mut self,
         submit_only_full_batches: bool,
     ) -> Result<(), Error> {
         self.batch_builder
-            .try_submit_batches(self.ethereum_l1.clone(), submit_only_full_batches, None)
+            .try_submit_oldest_batch(self.ethereum_l1.clone(), submit_only_full_batches, None)
             .await
     }
 
-    pub async fn try_submit_batches_with_coinbase(
+    pub async fn try_submit_oldest_batch_with_coinbase(
         &mut self,
         coinbase: Address,
     ) -> Result<(), Error> {
         self.batch_builder
-            .try_submit_batches(self.ethereum_l1.clone(), false, Some(coinbase))
+            .try_submit_oldest_batch(self.ethereum_l1.clone(), false, Some(coinbase))
             .await
     }
 

--- a/Node/src/node/batch_manager/mod.rs
+++ b/Node/src/node/batch_manager/mod.rs
@@ -91,10 +91,6 @@ impl BatchManager {
             .recover_from(txs.to_vec(), anchor_block_id, block.header.timestamp)
     }
 
-    pub fn get_config(&self) -> &BatchBuilderConfig {
-        self.batch_builder.get_config()
-    }
-
     pub async fn get_anchor_block_offset(&self, block_height: u64) -> Result<u64, Error> {
         debug!(
             "get_anchor_block_offset: Checking L2 block {}",

--- a/Node/src/node/batch_manager/mod.rs
+++ b/Node/src/node/batch_manager/mod.rs
@@ -252,6 +252,10 @@ impl BatchManager {
         !self.batch_builder.is_empty()
     }
 
+    pub fn get_number_of_batches(&self) -> u64 {
+        self.batch_builder.get_number_of_batches()
+    }
+
     pub fn reset_builder(&mut self) {
         warn!("Resetting batch builder");
         self.batch_builder =

--- a/Node/src/node/verifier.rs
+++ b/Node/src/node/verifier.rs
@@ -99,10 +99,7 @@ impl Verifier {
         Ok(())
     }
 
-    pub async fn submit_oldest_batch(&mut self) -> Result<(), Error> {
-        // TODO calculate batch params and decide is it possible to continue with it, be careful with timeShift
-        // Sould be fixed with https://github.com/NethermindEth/Taiko-Preconf-AVS/issues/303
-        // Now just submit all the batches
+    pub async fn try_submit_oldest_batch(&mut self) -> Result<(), Error> {
         self.batch_manager
             .try_submit_oldest_batch_with_coinbase(self.coinbase)
             .await

--- a/Node/src/node/verifier.rs
+++ b/Node/src/node/verifier.rs
@@ -62,6 +62,11 @@ impl Verifier {
 
         Ok(())
     }
+
+    pub async fn submit_batch_if_present(&self) -> Result<bool, Error> {
+        //TODO  if batch_manager.has_batches() {
+        Ok(false)
+    }
 }
 
 pub async fn handle_unprocessed_blocks(
@@ -93,9 +98,9 @@ pub async fn handle_unprocessed_blocks(
         // TODO calculate batch params and decide is it possible to continue with it, be careful with timeShift
         // Sould be fixed with https://github.com/NethermindEth/Taiko-Preconf-AVS/issues/303
         // Now just submit all the batches
-        info!("Submit batches");
+        info!("Submit batch");
         batch_manager
-            .try_submit_batches_with_coinbase(coinbase)
+            .try_submit_oldest_batch_with_coinbase(coinbase)
             .await?;
     } else {
         // The first block anchor id is not valid

--- a/Node/src/node/verifier.rs
+++ b/Node/src/node/verifier.rs
@@ -11,15 +11,25 @@ pub struct Verifier {
     taiko: Arc<Taiko>,
     taiko_geth_height: u64,
     verified_height: u64,
+    batch_manager: BatchManager,
+    coinbase: Address,
 }
 
 impl Verifier {
-    pub async fn new(taiko: Arc<Taiko>) -> Result<Self, Error> {
+    pub async fn new(taiko: Arc<Taiko>, batch_manager: BatchManager) -> Result<Self, Error> {
         let taiko_geth_height = taiko.get_latest_l2_block_id().await?;
-        Ok(Self::with_taiko_height(taiko_geth_height, taiko))
+        Ok(Self::new_with_taiko_height(
+            taiko_geth_height,
+            taiko,
+            batch_manager,
+        ))
     }
 
-    pub fn with_taiko_height(taiko_geth_height: u64, taiko: Arc<Taiko>) -> Self {
+    pub fn new_with_taiko_height(
+        taiko_geth_height: u64,
+        taiko: Arc<Taiko>,
+        batch_manager: BatchManager,
+    ) -> Self {
         debug!(
             "Verifier created with taiko_geth_height: {}",
             taiko_geth_height
@@ -28,14 +38,12 @@ impl Verifier {
             taiko,
             taiko_geth_height,
             verified_height: 0,
+            batch_manager,
+            coinbase: Address::ZERO,
         }
     }
 
-    pub async fn verify_submitted_blocks(
-        &mut self,
-        mut batch_manager: BatchManager,
-        taiko_inbox_height: u64,
-    ) -> Result<(), Error> {
+    pub async fn verify_submitted_blocks(&mut self, taiko_inbox_height: u64) -> Result<(), Error> {
         if self.taiko_geth_height > taiko_inbox_height
             && self.taiko_geth_height > self.verified_height
         {
@@ -48,68 +56,72 @@ impl Verifier {
                 .taiko
                 .get_l2_block_by_number(taiko_inbox_height + 1, false)
                 .await?;
-            let coinbase = first_block.header.beneficiary();
+            self.coinbase = first_block.header.beneficiary();
 
-            handle_unprocessed_blocks(
-                &mut batch_manager,
-                taiko_inbox_height,
-                self.taiko_geth_height,
-                coinbase,
-            )
-            .await?;
+            self.handle_unprocessed_blocks(taiko_inbox_height, self.taiko_geth_height)
+                .await?;
             self.verified_height = self.taiko_geth_height;
         }
 
         Ok(())
     }
 
-    pub async fn submit_batch_if_present(&self) -> Result<bool, Error> {
-        //TODO  if batch_manager.has_batches() {
-        Ok(false)
+    pub fn has_batches_to_submit(&self) -> bool {
+        self.batch_manager.has_batches()
     }
-}
 
-pub async fn handle_unprocessed_blocks(
-    batch_manager: &mut BatchManager,
-    taiko_inbox_height: u64,
-    taiko_geth_height: u64,
-    coinbase: Address,
-) -> Result<(), Error> {
-    let anchor_offset = batch_manager
-        .get_anchor_block_offset(taiko_inbox_height + 1)
-        .await?;
-    let mut extra_slots: u64 = 0;
-    // The first block anchor id is valid, so we can continue.
-    if batch_manager.is_anchor_block_offset_valid(anchor_offset) {
-        let start = std::time::Instant::now();
-        // recover all missed l2 blocks
-        info!("Recovering from L2 blocks for coinbase: {}", coinbase);
-        for current_height in taiko_inbox_height + 1..=taiko_geth_height {
-            batch_manager.recover_from_l2_block(current_height).await?;
+    pub async fn handle_unprocessed_blocks(
+        &mut self,
+        taiko_inbox_height: u64,
+        taiko_geth_height: u64,
+    ) -> Result<(), Error> {
+        let anchor_offset = self
+            .batch_manager
+            .get_anchor_block_offset(taiko_inbox_height + 1)
+            .await?;
+        let mut extra_slots: u64 = 0;
+        // The first block anchor id is valid, so we can continue.
+        if self
+            .batch_manager
+            .is_anchor_block_offset_valid(anchor_offset)
+        {
+            let start = std::time::Instant::now();
+            // recover all missed l2 blocks
+            info!("Recovering from L2 blocks for coinbase: {}", self.coinbase);
+            for current_height in taiko_inbox_height + 1..=taiko_geth_height {
+                self.batch_manager
+                    .recover_from_l2_block(current_height)
+                    .await?;
+            }
+            let elapsed = start.elapsed().as_secs();
+            extra_slots = elapsed / self.batch_manager.get_config().l1_slot_duration_sec;
+            info!(
+                "Recovered in {} seconds (extra_slots = {})",
+                elapsed, extra_slots
+            );
         }
-        let elapsed = start.elapsed().as_secs();
-        extra_slots = elapsed / batch_manager.get_config().l1_slot_duration_sec;
-        info!(
-            "Recovered in {} seconds (extra_slots = {})",
-            elapsed, extra_slots
-        );
+
+        if !self
+            .batch_manager
+            .is_anchor_block_offset_valid(anchor_offset + extra_slots)
+        {
+            // The first block anchor id is not valid
+            // Just do force reorg
+            warn!("Triggering L2 reorg");
+            return Err(anyhow::anyhow!(
+                "Error: L2 chain state may be inconsistent."
+            ));
+        }
+
+        Ok(())
     }
-    if batch_manager.is_anchor_block_offset_valid(anchor_offset + extra_slots) {
+
+    pub async fn submit_oldest_batch(&mut self) -> Result<(), Error> {
         // TODO calculate batch params and decide is it possible to continue with it, be careful with timeShift
         // Sould be fixed with https://github.com/NethermindEth/Taiko-Preconf-AVS/issues/303
         // Now just submit all the batches
-        info!("Submit batch");
-        batch_manager
-            .try_submit_oldest_batch_with_coinbase(coinbase)
-            .await?;
-    } else {
-        // The first block anchor id is not valid
-        // Just do force reorg
-        warn!("Triggering L2 reorg");
-        return Err(anyhow::anyhow!(
-            "Error: L2 chain state may be inconsistent."
-        ));
+        self.batch_manager
+            .try_submit_oldest_batch_with_coinbase(self.coinbase)
+            .await
     }
-
-    Ok(())
 }

--- a/Node/src/utils/config.rs
+++ b/Node/src/utils/config.rs
@@ -159,7 +159,7 @@ impl Config {
             .expect("HANDOVER_WINDOW_SLOTS must be a number");
 
         let handover_start_buffer_ms = std::env::var("HANDOVER_START_BUFFER_MS")
-            .unwrap_or("500".to_string())
+            .unwrap_or("6000".to_string())
             .parse::<u64>()
             .expect("HANDOVER_START_BUFFER_MS must be a number");
 


### PR DESCRIPTION
New thread is created every time we want to send new propose batch transaction. If there is already one thread waiting for the transaction result, we skip sending second tx until the first is done (or reverted).
When revert occurs, error signal is sent from the transaction monitor thread. Main preconfirmation loop process the error at the beginning and reorgs the L2 chain if needed.