### PR TITLE
common version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 default-members = ["node"]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.2.84"
 edition = "2024"
 repository = "https://github.com/NethermindEth/Taiko-Preconf-AVS"
 license = "MIT"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taiko_preconf_avs_node"
-version = "0.2.84"
+version.workspace = true
 edition.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/tools/p2p_node/p2p_boot_node/Cargo.toml
+++ b/tools/p2p_node/p2p_boot_node/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "p2p-boot-node"
 publish = false
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/tools/p2p_node/p2p_network/Cargo.toml
+++ b/tools/p2p_node/p2p_network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "p2p-network"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/tools/p2p_node/p2p_test_node/Cargo.toml
+++ b/tools/p2p_node/p2p_test_node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "p2p-node"
-version = "0.1.0"
+version.workspace = true
 publish = false
 edition.workspace = true
 repository.workspace = true


### PR DESCRIPTION
# 🚀 What’s this PR do?

- [x] Use a single workspace version across all crates for the ease of updates and and a single point of truth for Docker image tags

---

### 📎 Related issues (optional)

Related to https://github.com/NethermindEth/Taiko-Preconf-AVS/issues/474

## 🧠 Context

When a multicomponent software (e.g. represented by a Rust workspace) is updated, for users it is easy to align different components from the point of compatibility if the components following the same versioning

## ✅ Checklist

- [x] I’ve tested this locally
- [x] I’ve added relevant docs or comments
- [x] I’ve updated or created tests if needed
- [x] The branch with the feature is named `feature/<name>`