### PR TITLE
Get the transaction status before checking the error channel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4790,7 +4790,7 @@ dependencies = [
 
 [[package]]
 name = "p2p-boot-node"
-version = "0.2.96"
+version = "0.2.97"
 dependencies = [
  "anyhow",
  "discv5",
@@ -4802,7 +4802,7 @@ dependencies = [
 
 [[package]]
 name = "p2p-network"
-version = "0.2.96"
+version = "0.2.97"
 dependencies = [
  "discv5",
  "futures",
@@ -4817,7 +4817,7 @@ dependencies = [
 
 [[package]]
 name = "p2p-node"
-version = "0.2.96"
+version = "0.2.97"
 dependencies = [
  "anyhow",
  "jsonrpsee",
@@ -6355,7 +6355,7 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "taiko_preconf_avs_node"
-version = "0.2.96"
+version = "0.2.97"
 dependencies = [
  "alloy",
  "alloy-json-rpc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 default-members = ["node"]
 
 [workspace.package]
-version = "0.2.96"
+version = "0.2.97"
 edition = "2024"
 repository = "https://github.com/NethermindEth/Taiko-Preconf-AVS"
 license = "MIT"

--- a/node/src/node/mod.rs
+++ b/node/src/node/mod.rs
@@ -416,9 +416,9 @@ impl Node {
             }
         }
 
-        if current_status.is_submitter() {
+        if current_status.is_submitter() && !transaction_in_progress {
             // first check verifier
-            if self.has_verified_unproposed_batches().await? && !transaction_in_progress {
+            if self.has_verified_unproposed_batches().await? {
                 if let Err(err) = self
                     .batch_manager
                     .try_submit_oldest_batch(current_status.is_preconfer())

--- a/node/src/utils/config.rs
+++ b/node/src/utils/config.rs
@@ -253,7 +253,7 @@ impl Config {
             .expect("MAX_ATTEMPTS_TO_WAIT_TX must be a number");
 
         let delay_between_tx_attempts_sec = std::env::var("DELAY_BETWEEN_TX_ATTEMPTS_SEC")
-            .unwrap_or("15".to_string())
+            .unwrap_or("27".to_string())
             .parse::<u64>()
             .expect("DELAY_BETWEEN_TX_ATTEMPTS_SEC must be a number");
 

--- a/node/src/utils/config.rs
+++ b/node/src/utils/config.rs
@@ -107,7 +107,7 @@ impl Config {
 
         #[cfg(feature = "extra-gas-percentage")]
         let extra_gas_percentage = std::env::var("EXTRA_GAS_PERCENTAGE")
-            .unwrap_or("20".to_string())
+            .unwrap_or("50".to_string())
             .parse::<u64>()
             .expect("EXTRA_GAS_PERCENTAGE must be a number");
 


### PR DESCRIPTION
We check error channel at the beginning of the main preconfirmation loop. We cannot send new transaction without checking error channel because there can be some error left. To prevent the race condition I've added transaction progress check before reading error channel. This guarantee that we won't send new transaction before checking the errors from previous one.