### PR TITLE
Fix: Update GitHub Actions workflow for multi-arch Docker build and push

### DIFF
--- a/.github/workflows/node_docker_build.yml
+++ b/.github/workflows/node_docker_build.yml
@@ -19,7 +19,7 @@ jobs:
   build:
     name: Build per-arch image
     runs-on: ${{ matrix.os }}
-    if: github.repository == 'gehlotanish/catalyst-temp'
+    if: github.repository == 'NethermindEth/Catalyst'
     strategy:
       matrix:
         include:


### PR DESCRIPTION
Description:

This PR updates the GitHub Actions workflow to build and push the catalyst-node Docker image with multi-architecture support (amd64 and arm64) and ensures the correct creation of manifests for Docker Hub.
Key Changes:

1. Removed temporary image creation – builds now directly target the final tags.
2. Multi-arch support – builds both amd64 and arm64 images using a matrix strategy.
3. Final image tags – pushes latest and semantic version tags (e.g., vX.Y.Z) to Docker Hub.
4. Manifest creation – ensures a single multi-architecture manifest includes both platforms.
