### PR TITLE
feat: auto-reorg on L1 failure, surge_txStatus RPC, and recovery fixes

### DIFF
--- a/realtime/src/node/mod.rs
+++ b/realtime/src/node/mod.rs
@@ -181,12 +181,29 @@ impl Node {
                             warn!("Async submission failed: {}. Reorging preconfirmed L2 blocks.", e);
                             self.recover_from_failed_submission().await?;
                         }
+                        // Return early — l2_slot_info is stale after reorg recovery.
+                        // The next heartbeat will pick up fresh state.
+                        return Ok(());
                     }
                 }
             }
 
-            self.check_transaction_error_channel(&current_status, &l2_slot_info)
-                .await?;
+            // Check for transaction errors (reverts detected after mining)
+            match self.transaction_error_channel.try_recv() {
+                Ok(error) => {
+                    self.handle_transaction_error(&error, &current_status, &l2_slot_info)
+                        .await?;
+                    // Return early — l2_slot_info is stale after reorg recovery.
+                    return Ok(());
+                }
+                Err(err) => match err {
+                    TryRecvError::Empty => {}
+                    TryRecvError::Disconnected => {
+                        self.cancel_token.cancel_on_critical_error();
+                        return Err(anyhow::anyhow!("Transaction error channel disconnected"));
+                    }
+                },
+            }
         }
 
         if current_status.is_preconfirmation_start_slot() {
@@ -406,25 +423,6 @@ impl Node {
         Ok(())
     }
 
-    async fn check_transaction_error_channel(
-        &mut self,
-        current_status: &OperatorStatus,
-        l2_slot_info: &L2SlotInfoV2,
-    ) -> Result<(), Error> {
-        match self.transaction_error_channel.try_recv() {
-            Ok(error) => {
-                self.handle_transaction_error(&error, current_status, l2_slot_info)
-                    .await
-            }
-            Err(err) => match err {
-                TryRecvError::Empty => Ok(()),
-                TryRecvError::Disconnected => {
-                    self.cancel_token.cancel_on_critical_error();
-                    Err(anyhow::anyhow!("Transaction error channel disconnected"))
-                }
-            },
-        }
-    }
 
     fn print_current_slots_info(
         &self,

--- a/realtime/src/node/mod.rs
+++ b/realtime/src/node/mod.rs
@@ -223,10 +223,9 @@ impl Node {
                 .await
             {
                 self.head_verifier.log_error().await;
-                self.cancel_token.cancel_on_critical_error();
-                return Err(anyhow::anyhow!(
-                    "Unexpected L2 head detected. Restarting node..."
-                ));
+                warn!("Unexpected L2 head detected. Attempting recovery via reorg.");
+                self.recover_from_failed_submission().await?;
+                return Ok(());
             }
 
             let l2_slot_context = L2SlotContext {

--- a/realtime/src/node/mod.rs
+++ b/realtime/src/node/mod.rs
@@ -178,7 +178,10 @@ impl Node {
                             )
                             .await?;
                         } else {
-                            warn!("Async submission failed: {}. Reorging preconfirmed L2 blocks.", e);
+                            warn!(
+                                "Async submission failed: {}. Reorging preconfirmed L2 blocks.",
+                                e
+                            );
                             self.recover_from_failed_submission().await?;
                         }
                         // Return early — l2_slot_info is stale after reorg recovery.
@@ -421,7 +424,6 @@ impl Node {
         }
         Ok(())
     }
-
 
     fn print_current_slots_info(
         &self,

--- a/realtime/src/node/mod.rs
+++ b/realtime/src/node/mod.rs
@@ -178,9 +178,8 @@ impl Node {
                             )
                             .await?;
                         } else {
-                            error!("Async submission failed: {}. Restarting node.", e);
-                            self.cancel_token.cancel_on_critical_error();
-                            return Err(anyhow::anyhow!("Async submission failed: {}", e));
+                            warn!("Async submission failed: {}. Reorging preconfirmed L2 blocks.", e);
+                            self.recover_from_failed_submission().await?;
                         }
                     }
                 }
@@ -269,6 +268,19 @@ impl Node {
         Ok(())
     }
 
+    async fn recover_from_failed_submission(&mut self) -> Result<(), Error> {
+        self.proposal_manager.reorg_unproposed_blocks().await?;
+        self.proposal_manager.reset_builder().await?;
+
+        let l2_slot_info = self.taiko.get_l2_slot_info().await?;
+        self.head_verifier
+            .set(l2_slot_info.parent_id(), *l2_slot_info.parent_hash())
+            .await;
+
+        info!("Recovery complete. Resuming preconfirmation loop.");
+        Ok(())
+    }
+
     async fn handle_transaction_error(
         &mut self,
         error: &TransactionError,
@@ -308,12 +320,12 @@ impl Node {
                 ))
             }
             TransactionError::EstimationFailed => {
-                self.cancel_token.cancel_on_critical_error();
-                Err(anyhow::anyhow!("Transaction estimation failed, exiting"))
+                warn!("L1 transaction estimation failed. Reorging preconfirmed L2 blocks.");
+                self.recover_from_failed_submission().await
             }
             TransactionError::TransactionReverted => {
-                self.cancel_token.cancel_on_critical_error();
-                Err(anyhow::anyhow!("Transaction reverted, exiting"))
+                warn!("L1 transaction reverted. Reorging preconfirmed L2 blocks.");
+                self.recover_from_failed_submission().await
             }
             TransactionError::OldestForcedInclusionDue => {
                 // No forced inclusions in RealTime, but handle gracefully

--- a/realtime/src/node/proposal_manager/async_submitter.rs
+++ b/realtime/src/node/proposal_manager/async_submitter.rs
@@ -17,6 +17,7 @@ use tracing::info;
 
 pub struct SubmissionResult {
     pub new_last_finalized_block_hash: B256,
+    pub new_last_finalized_block_number: u64,
 }
 
 struct InFlightSubmission {
@@ -229,6 +230,7 @@ async fn submission_task(
 
             return Ok(SubmissionResult {
                 new_last_finalized_block_hash: proposal.checkpoint.blockHash,
+                new_last_finalized_block_number: proposal.checkpoint.blockNumber.to::<u64>(),
             });
         }
 
@@ -305,6 +307,7 @@ async fn submission_task(
 
     // Step 3: After successful submission, the new lastFinalizedBlockHash is the checkpoint's blockHash
     let new_last_finalized_block_hash = proposal.checkpoint.blockHash;
+    let new_last_finalized_block_number = proposal.checkpoint.blockNumber.to::<u64>();
 
     // Step 4: Spawn user-op status tracker
     if let (Some(hash_rx), Some(result_rx), Some(store)) =
@@ -375,5 +378,6 @@ async fn submission_task(
 
     Ok(SubmissionResult {
         new_last_finalized_block_hash,
+        new_last_finalized_block_number,
     })
 }

--- a/realtime/src/node/proposal_manager/async_submitter.rs
+++ b/realtime/src/node/proposal_manager/async_submitter.rs
@@ -255,7 +255,31 @@ async fn submission_task(
             }
         }
 
-        let proof = raiko_client.get_proof(&request).await?;
+        let proof = match raiko_client.get_proof(&request).await {
+            Ok(proof) => proof,
+            Err(e) => {
+                if let Some(ref store) = status_store {
+                    let reason = format!("Proof generation failed: {}", e);
+                    for op in &proposal.user_ops {
+                        store.set(
+                            op.id,
+                            &UserOpStatus::Rejected {
+                                reason: reason.clone(),
+                            },
+                        );
+                    }
+                    for id in &proposal.l2_user_op_ids {
+                        store.set(
+                            *id,
+                            &UserOpStatus::Rejected {
+                                reason: reason.clone(),
+                            },
+                        );
+                    }
+                }
+                return Err(e);
+            }
+        };
         proposal.zk_proof = Some(proof);
     }
 

--- a/realtime/src/node/proposal_manager/bridge_handler.rs
+++ b/realtime/src/node/proposal_manager/bridge_handler.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::{net::SocketAddr, sync::Arc};
 use tokio::sync::mpsc::{self, Receiver};
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "status")]
@@ -92,11 +92,21 @@ pub enum UserOpRouting {
     L2Direct { user_op: UserOp },
 }
 
+#[derive(Debug, Deserialize)]
+struct TxStatusRequest {
+    #[serde(default, rename = "userOpId")]
+    user_op_id: Option<u64>,
+    #[serde(default, rename = "txHash")]
+    tx_hash: Option<B256>,
+}
+
 #[derive(Clone)]
 struct BridgeRpcContext {
     tx: mpsc::Sender<UserOp>,
     status_store: UserOpStatusStore,
     next_id: Arc<AtomicU64>,
+    taiko: Arc<Taiko>,
+    last_finalized_block_number: Arc<AtomicU64>,
 }
 
 pub struct BridgeHandler {
@@ -116,6 +126,7 @@ impl BridgeHandler {
         cancellation_token: CancellationToken,
         l1_chain_id: u64,
         l2_chain_id: u64,
+        last_finalized_block_number: Arc<AtomicU64>,
     ) -> Result<Self, anyhow::Error> {
         let (tx, rx) = mpsc::channel::<UserOp>(1024);
         let status_store = UserOpStatusStore::open("data/user_op_status")?;
@@ -124,6 +135,8 @@ impl BridgeHandler {
             tx,
             status_store: status_store.clone(),
             next_id: Arc::new(AtomicU64::new(1)),
+            taiko: taiko.clone(),
+            last_finalized_block_number,
         };
 
         let server = ServerBuilder::default()
@@ -177,6 +190,74 @@ impl BridgeHandler {
                     -32001,
                     "UserOp not found",
                     Some(format!("No user operation with id {}", id)),
+                )),
+            }
+        })?;
+
+        module.register_async_method("surge_txStatus", |params, ctx, _| async move {
+            let request: TxStatusRequest = params.parse()?;
+
+            match (request.user_op_id, request.tx_hash) {
+                (Some(id), None) => {
+                    // Existing userOpId lookup via status store
+                    match ctx.status_store.get(id) {
+                        Some(status) => serde_json::to_value(status).map_err(|e| {
+                            jsonrpsee::types::ErrorObjectOwned::owned(
+                                -32603,
+                                "Serialization error",
+                                Some(format!("{}", e)),
+                            )
+                        }),
+                        None => Err(jsonrpsee::types::ErrorObjectOwned::owned(
+                            -32001,
+                            "UserOp not found",
+                            Some(format!("No user operation with id {}", id)),
+                        )),
+                    }
+                }
+                (None, Some(hash)) => {
+                    // Look up L2 transaction by hash
+                    let tx = ctx.taiko.get_transaction_by_hash(hash).await.map_err(|e| {
+                        debug!("Transaction {} not found on L2: {}", hash, e);
+                        jsonrpsee::types::ErrorObjectOwned::owned(
+                            -32001,
+                            "Transaction not found",
+                            Some(format!("L2 transaction {} not found: {}", hash, e)),
+                        )
+                    })?;
+
+                    let block_number = tx.block_number.ok_or_else(|| {
+                        jsonrpsee::types::ErrorObjectOwned::owned(
+                            -32001,
+                            "Transaction pending",
+                            Some("Transaction has not been included in a block yet".to_string()),
+                        )
+                    })?;
+
+                    let finalized = ctx.last_finalized_block_number.load(Ordering::Relaxed);
+
+                    let status = if block_number <= finalized {
+                        UserOpStatus::Executed
+                    } else {
+                        UserOpStatus::ProvingBlock {
+                            block_id: block_number,
+                        }
+                    };
+
+                    serde_json::to_value(status).map_err(|e| {
+                        jsonrpsee::types::ErrorObjectOwned::owned(
+                            -32603,
+                            "Serialization error",
+                            Some(format!("{}", e)),
+                        )
+                    })
+                }
+                _ => Err(jsonrpsee::types::ErrorObjectOwned::owned(
+                    -32602,
+                    "Invalid params",
+                    Some(
+                        "Provide exactly one of 'userOpId' or 'txHash'".to_string(),
+                    ),
                 )),
             }
         })?;

--- a/realtime/src/node/proposal_manager/bridge_handler.rs
+++ b/realtime/src/node/proposal_manager/bridge_handler.rs
@@ -255,9 +255,7 @@ impl BridgeHandler {
                 _ => Err(jsonrpsee::types::ErrorObjectOwned::owned(
                     -32602,
                     "Invalid params",
-                    Some(
-                        "Provide exactly one of 'userOpId' or 'txHash'".to_string(),
-                    ),
+                    Some("Provide exactly one of 'userOpId' or 'txHash'".to_string()),
                 )),
             }
         })?;

--- a/realtime/src/node/proposal_manager/mod.rs
+++ b/realtime/src/node/proposal_manager/mod.rs
@@ -136,8 +136,7 @@ impl BatchManager {
             Some(Ok(result)) => {
                 info!(
                     "Submission completed. New last finalized block: number={}, hash={}",
-                    result.new_last_finalized_block_number,
-                    result.new_last_finalized_block_hash,
+                    result.new_last_finalized_block_number, result.new_last_finalized_block_hash,
                 );
                 self.last_finalized_block_hash = result.new_last_finalized_block_hash;
                 self.last_finalized_block_number

--- a/realtime/src/node/proposal_manager/mod.rs
+++ b/realtime/src/node/proposal_manager/mod.rs
@@ -26,6 +26,7 @@ use common::{
     },
     utils::cancellation_token::CancellationToken,
 };
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::{net::SocketAddr, sync::Arc};
 use tokio::sync::Mutex;
 use tracing::{debug, error, info, warn};
@@ -46,6 +47,7 @@ pub struct BatchManager {
     #[allow(dead_code)]
     cancel_token: CancellationToken,
     last_finalized_block_hash: B256,
+    last_finalized_block_number: Arc<AtomicU64>,
 }
 
 impl BatchManager {
@@ -86,6 +88,9 @@ impl BatchManager {
                 e
             )
         })?;
+
+        let last_finalized_block_number = Arc::new(AtomicU64::new(0));
+
         let bridge_handler = Arc::new(Mutex::new(
             BridgeHandler::new(
                 bridge_addr,
@@ -94,6 +99,7 @@ impl BatchManager {
                 cancel_token.clone(),
                 l1_chain_id,
                 l2_chain_id,
+                last_finalized_block_number.clone(),
             )
             .await?,
         ));
@@ -119,6 +125,7 @@ impl BatchManager {
             metrics,
             cancel_token,
             last_finalized_block_hash,
+            last_finalized_block_number,
         })
     }
 
@@ -128,10 +135,13 @@ impl BatchManager {
         match self.async_submitter.try_recv_result() {
             Some(Ok(result)) => {
                 info!(
-                    "Submission completed. New last finalized block hash: {}",
-                    result.new_last_finalized_block_hash
+                    "Submission completed. New last finalized block: number={}, hash={}",
+                    result.new_last_finalized_block_number,
+                    result.new_last_finalized_block_hash,
                 );
                 self.last_finalized_block_hash = result.new_last_finalized_block_hash;
+                self.last_finalized_block_number
+                    .store(result.new_last_finalized_block_number, Ordering::Relaxed);
                 Some(Ok(()))
             }
             Some(Err(e)) => Some(Err(e)),
@@ -511,6 +521,10 @@ impl BatchManager {
         };
 
         let l2_head = self.taiko.get_latest_l2_block_id().await?;
+
+        // Always update the shared finalized block number for RPC status queries
+        self.last_finalized_block_number
+            .store(last_proposed_block_number, Ordering::Relaxed);
 
         if l2_head <= last_proposed_block_number {
             info!(


### PR DESCRIPTION
## Summary

**1. Auto-reorg L2 blocks on L1 transaction failure**
- When an L1 multicall reverts, gas estimation fails, or async submission (Raiko proof fetch) fails, Catalyst now reorgs preconfirmed L2 blocks back to the last finalized state and resumes the preconfirmation loop — instead of shutting down.
- Adds `recover_from_failed_submission()` which reuses existing `reorg_unproposed_blocks()` machinery, resets the batch builder, and resyncs the head verifier.
- Three error paths now trigger recovery instead of `cancel_on_critical_error()`:
  - `TransactionReverted` — L1 multicall reverted on-chain
  - `EstimationFailed` — L1 gas estimation failed
  - Generic async submission error — e.g. Raiko proof fetch failure

**2. `surge_txStatus` RPC method**
- New unified RPC method that accepts either `{ "userOpId": 123 }` or `{ "txHash": "0x..." }`
- For `userOpId`: delegates to existing status store (same as `surge_userOpStatus`)
- For `txHash`: queries L2 via `eth_getTransactionByHash`, compares block number against last finalized block number on L1
  - block <= finalized -> `Executed`
  - block > finalized -> `ProvingBlock { block_id }`
- A shared `AtomicU64` tracks `last_finalized_block_number`, updated on successful submission and during reorg recovery
- `surge_userOpStatus` remains unchanged for backward compatibility

**3. Bug fixes found during live testing**
- Return early after reorg recovery to avoid stale head verification crash
- Mark user ops as `Rejected` when Raiko proof fetch fails (previously stuck at `ProvingBlock` forever)
- Recover from unexpected L2 head (external geth reorg race) instead of crashing — handles the case where geth detects an L1 revert and reorgs L2 before the `TransactionReverted` error arrives in the channel

## Test plan
- [x] Raiko failure triggers reorg + resume (not shutdown)
- [x] L1 tx revert triggers reorg + resume via head verifier recovery
- [x] User ops marked Rejected on proof failure
- [x] Node survives external geth reorg after L1 revert
- [x] Verify `surge_txStatus` with `userOpId` returns correct status
- [x] Verify `surge_txStatus` with `txHash` for finalized block returns `Executed`
- [x] Verify `surge_txStatus` with `txHash` for unfinalized block returns `ProvingBlock`