### PR TITLE
feat: update raiko caller for v3 batch/realtime API changes

### DIFF
--- a/realtime/src/node/proposal_manager/async_submitter.rs
+++ b/realtime/src/node/proposal_manager/async_submitter.rs
@@ -168,8 +168,15 @@ async fn submission_task(
             },
         }];
 
+        let l2_block_hashes: Vec<String> = proposal
+            .l2_block_hashes
+            .iter()
+            .map(|h| format!("0x{}", hex::encode(h)))
+            .collect();
+
         let request = RaikoProofRequest {
             l2_block_numbers,
+            l2_block_hashes: Some(l2_block_hashes),
             proof_type: raiko_client.proof_type.raiko_proof_type().to_string(),
             max_anchor_block_number: proposal.max_anchor_block_number,
             last_finalized_block_hash: format!(

--- a/realtime/src/node/proposal_manager/batch_builder.rs
+++ b/realtime/src/node/proposal_manager/batch_builder.rs
@@ -97,6 +97,7 @@ impl BatchBuilder {
             l2_user_op_ids: vec![],
             signal_slots: vec![],
             l1_calls: vec![],
+            l2_block_hashes: vec![],
             zk_proof: None,
         });
     }
@@ -173,6 +174,9 @@ impl BatchBuilder {
 
     pub fn set_proposal_checkpoint(&mut self, checkpoint: Checkpoint) -> Result<&Proposal, Error> {
         if let Some(current_proposal) = self.current_proposal.as_mut() {
+            current_proposal
+                .l2_block_hashes
+                .push(checkpoint.blockHash);
             current_proposal.checkpoint = checkpoint.clone();
             debug!("Update proposal checkpoint: {:?}", checkpoint);
             Ok(current_proposal)

--- a/realtime/src/node/proposal_manager/batch_builder.rs
+++ b/realtime/src/node/proposal_manager/batch_builder.rs
@@ -174,9 +174,7 @@ impl BatchBuilder {
 
     pub fn set_proposal_checkpoint(&mut self, checkpoint: Checkpoint) -> Result<&Proposal, Error> {
         if let Some(current_proposal) = self.current_proposal.as_mut() {
-            current_proposal
-                .l2_block_hashes
-                .push(checkpoint.blockHash);
+            current_proposal.l2_block_hashes.push(checkpoint.blockHash);
             current_proposal.checkpoint = checkpoint.clone();
             debug!("Update proposal checkpoint: {:?}", checkpoint);
             Ok(current_proposal)

--- a/realtime/src/node/proposal_manager/proposal.rs
+++ b/realtime/src/node/proposal_manager/proposal.rs
@@ -34,6 +34,9 @@ pub struct Proposal {
     pub signal_slots: Vec<FixedBytes<32>>,
     pub l1_calls: Vec<L1Call>,
 
+    // L2 block hashes (accumulated as blocks are preconfirmed, used for Raiko cache key)
+    pub l2_block_hashes: Vec<B256>,
+
     // ZK proof (populated after Raiko call)
     pub zk_proof: Option<Vec<u8>>,
 }

--- a/realtime/src/raiko/mod.rs
+++ b/realtime/src/raiko/mod.rs
@@ -185,7 +185,7 @@ impl RaikoClient {
                 let msg = body.message.unwrap_or_default();
                 // "proof not found" means the proof expired from cache (Redis TTL) or was
                 // never submitted. Re-submit the full request with sources+blobs.
-                if msg.contains("proof not found") {
+                if msg.to_lowercase().contains("proof not found") {
                     warn!(
                         "Raiko: proof not found (expired or never submitted), re-submitting... (attempt {})",
                         attempt + 1

--- a/realtime/src/raiko/mod.rs
+++ b/realtime/src/raiko/mod.rs
@@ -23,6 +23,8 @@ pub struct RaikoClient {
 #[derive(Serialize)]
 pub struct RaikoProofRequest {
     pub l2_block_numbers: Vec<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub l2_block_hashes: Option<Vec<String>>,
     pub proof_type: String,
     pub max_anchor_block_number: u64,
     pub last_finalized_block_hash: String,
@@ -56,7 +58,7 @@ pub struct RaikoBlobSlice {
     pub timestamp: u64,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct RaikoCheckpoint {
     pub block_number: u64,
     pub block_hash: String,
@@ -112,14 +114,46 @@ impl RaikoClient {
         }
     }
 
-    /// Request a proof and poll until ready.
-    /// Returns the raw proof bytes.
+    /// Submit a proof request and poll until ready.
+    ///
+    /// Flow:
+    /// 1. First request sends full sources+blobs to trigger proving.
+    /// 2. Subsequent polls send empty sources+blobs (the cache key fields —
+    ///    `l2_block_numbers`, `l2_block_hashes`, etc. — are still included).
+    /// 3. If a poll returns "proof not found" (expired from cache), we
+    ///    re-submit the full request with sources+blobs.
     pub async fn get_proof(&self, request: &RaikoProofRequest) -> Result<Vec<u8>, Error> {
         let url = format!("{}/v3/proof/batch/realtime", self.base_url);
 
-        for attempt in 0..self.max_retries {
-            let mut req = self.client.post(&url).json(request);
+        // Build the polling variant: same cache-key fields, empty sources+blobs.
+        let poll_request = RaikoProofRequest {
+            l2_block_numbers: request.l2_block_numbers.clone(),
+            l2_block_hashes: request.l2_block_hashes.clone(),
+            proof_type: request.proof_type.clone(),
+            max_anchor_block_number: request.max_anchor_block_number,
+            last_finalized_block_hash: request.last_finalized_block_hash.clone(),
+            basefee_sharing_pctg: request.basefee_sharing_pctg,
+            network: request.network.clone(),
+            l1_network: request.l1_network.clone(),
+            prover: request.prover.clone(),
+            signal_slots: request.signal_slots.clone(),
+            sources: vec![],
+            blobs: vec![],
+            checkpoint: request.checkpoint.clone(),
+            blob_proof_type: request.blob_proof_type.clone(),
+        };
 
+        // First attempt always sends the full request to trigger proving.
+        let mut use_full_request = true;
+
+        for attempt in 0..self.max_retries {
+            let body_to_send = if use_full_request {
+                request
+            } else {
+                &poll_request
+            };
+
+            let mut req = self.client.post(&url).json(body_to_send);
             if let Some(ref key) = self.api_key {
                 req = req.header("X-API-KEY", key);
             }
@@ -128,11 +162,16 @@ impl RaikoClient {
             let http_status = resp.status();
             let raw_body = resp.text().await?;
             debug!(
-                "Raiko response (attempt {}): HTTP {} | body: {}",
+                "Raiko response (attempt {}, full={}): HTTP {} | body: {}",
                 attempt + 1,
+                use_full_request,
                 http_status,
                 raw_body
             );
+
+            // After the first submission, switch to polling (empty sources+blobs).
+            use_full_request = false;
+
             let body: RaikoResponse = serde_json::from_str(&raw_body).map_err(|e| {
                 anyhow::anyhow!(
                     "Failed to parse Raiko response (HTTP {}): {} | body: {}",
@@ -143,10 +182,19 @@ impl RaikoClient {
             })?;
 
             if body.status == "error" {
-                return Err(anyhow::anyhow!(
-                    "Raiko proof failed: {}",
-                    body.message.unwrap_or_default()
-                ));
+                let msg = body.message.unwrap_or_default();
+                // "proof not found" means the proof expired from cache (Redis TTL) or was
+                // never submitted. Re-submit the full request with sources+blobs.
+                if msg.contains("proof not found") {
+                    warn!(
+                        "Raiko: proof not found (expired or never submitted), re-submitting... (attempt {})",
+                        attempt + 1
+                    );
+                    use_full_request = true;
+                    tokio::time::sleep(self.poll_interval).await;
+                    continue;
+                }
+                return Err(anyhow::anyhow!("Raiko proof failed: {}", msg));
             }
 
             match body.data {


### PR DESCRIPTION
## Summary
- Adapts the raiko proof caller to the updated `/v3/proof/batch/realtime` endpoint ([NethermindEth/raiko#56](https://github.com/NethermindEth/raiko/pull/56))
- Adds `l2_block_hashes` to `RaikoProofRequest` and `Proposal`, accumulated from engine API responses as each L2 block is preconfirmed — used as part of the raiko cache key so reorgs don't serve stale proofs
- Implements proper two-phase submit/poll flow: first request sends full sources+blobs to trigger proving, subsequent polls send empty sources+blobs
- Handles new "proof not found" error (cache expiry) by re-submitting the full request with sources+blobs

## Test plan
- [ ] Verify proof request JSON includes `l2_block_hashes` field with correct hex-encoded hashes
- [ ] Verify polling requests send empty `sources` and `blobs` arrays
- [ ] Verify "proof not found" error triggers re-submission with full payload
- [ ] End-to-end test with raiko instance running the updated endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)