### PR TITLE
feat(realtime): encrypt proposal blobs and consume forced inclusions

### DIFF
--- a/.github/workflows/node_docker_build.yml
+++ b/.github/workflows/node_docker_build.yml
@@ -19,7 +19,8 @@ env:
   DOCKER_PUBLIC_REGISTRY: docker.io
   DOCKER_PUBLIC_REPOSITORY: nethermind/catalyst-node
   DOCKER_REGISTRY: nethermind.jfrog.io
-  DOCKER_REPOSITORY_STAGING: core-oci-local-staging/catalyst-node
+  DOCKER_REPOSITORY_PROD: core-oci-local-prod/catalyst-node
+  MASTER_BRANCH: refs/heads/master
 
 jobs:
   build:
@@ -50,7 +51,8 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - uses: docker/login-action@v3
+      - name: Login to JFrog Artifactory
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.DOCKER_REGISTRY }}
           username: ${{ secrets.ARTIFACTORY_CORE_USERNAME }}
@@ -64,24 +66,22 @@ jobs:
           file: Dockerfile
           platforms: ${{ matrix.platform }}
           push: true
-          outputs: type=image,name=${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_REPOSITORY_STAGING }},push-by-digest=true,name-canonical=true
+          build-args: |
+            BLST_PORTABLE=1
+          outputs: type=image,name=${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_REPOSITORY_PROD }},push-by-digest=true,name-canonical=true
 
       - name: Set digest output
         id: digest
         run: |
-          if [ "${{ matrix.short }}" = "amd64" ]; then
-            echo "amd64=${{ steps.build.outputs.digest }}" >> $GITHUB_OUTPUT
-          fi
-          if [ "${{ matrix.short }}" = "arm64" ]; then
-            echo "arm64=${{ steps.build.outputs.digest }}" >> $GITHUB_OUTPUT
-          fi
+          echo "${{ matrix.short }}=${{ steps.build.outputs.digest }}" >> $GITHUB_OUTPUT
 
   merge:
     name: Merge and push multi-arch manifest
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: docker/login-action@v3
+      - name: Login to JFrog Artifactory
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.DOCKER_REGISTRY }}
           username: ${{ secrets.ARTIFACTORY_CORE_USERNAME }}
@@ -90,79 +90,139 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Determine event type and set tags
-        id: event
+      - name: Calculate SHA tag
+        id: sha
         run: |
-          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
-            echo "is_tag=true" >> $GITHUB_OUTPUT
-            echo "is_branch=false" >> $GITHUB_OUTPUT
-            VERSION=${GITHUB_REF#refs/tags/}
-            echo "version=$VERSION" >> $GITHUB_OUTPUT
-            echo "tag_list=type=raw,value=$VERSION" >> $GITHUB_OUTPUT
-          else
-            echo "is_tag=false" >> $GITHUB_OUTPUT
-            echo "is_branch=true" >> $GITHUB_OUTPUT
+          SHORT_SHA="${{ github.sha }}"
+          SHORT_SHA=${SHORT_SHA:0:7}
+          echo "tag=sha-${SHORT_SHA}" >> $GITHUB_OUTPUT
+          echo "short=${SHORT_SHA}" >> $GITHUB_OUTPUT
+
+      - name: Determine tags and event type
+        id: tags
+        run: |
+          REF="${{ github.ref }}"
+          REALTIME_TAG="realtime-${{ steps.sha.outputs.short }}"
+          SOURCE_PROMOTE_TAG="${{ steps.sha.outputs.tag }}"
+          IS_MASTER=false
+          IS_TAG=false
+          VERSION_TAG=""
+          PROMOTE_TAGS="$REALTIME_TAG"
+
+          if [[ "$REF" == refs/tags/* ]]; then
+            IS_TAG=true
+            VERSION_TAG=${REF#refs/tags/}
+            echo "tag_list=type=raw,value=$VERSION_TAG" >> $GITHUB_OUTPUT
+          elif [[ "$REF" == ${{ env.MASTER_BRANCH }} ]]; then
+            IS_MASTER=true
             echo "tag_list=type=raw,value=latest" >> $GITHUB_OUTPUT
+          else
+            echo "tag_list=type=sha,value=${{ github.sha }}" >> $GITHUB_OUTPUT
           fi
 
-      - name: Docker meta
+          echo "is_master=$IS_MASTER" >> $GITHUB_OUTPUT
+          echo "is_tag=$IS_TAG" >> $GITHUB_OUTPUT
+          echo "version_tag=$VERSION_TAG" >> $GITHUB_OUTPUT
+          echo "source_promote_tag=$SOURCE_PROMOTE_TAG" >> $GITHUB_OUTPUT
+          echo "promote_tags=$PROMOTE_TAGS" >> $GITHUB_OUTPUT
+          echo "PROMOTE_TAGS=$PROMOTE_TAGS" >> $GITHUB_ENV
+
+      - name: Generate Docker metadata
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_REPOSITORY_STAGING }}
-          tags: ${{ steps.event.outputs.tag_list }}
+          images: ${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_REPOSITORY_PROD }}
+          tags: ${{ steps.tags.outputs.tag_list }}
 
-      - name: Create manifest list and push
+      - name: Create and push manifest list
+        run: |
+          # Filter out "latest" tag if not on master branch
+          if [[ "${{ steps.tags.outputs.is_master }}" != "true" ]]; then
+            FILTERED_TAGS=$(jq -cr '.tags | map(select(. | endswith(":latest") | not)) | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON")
+          else
+            FILTERED_TAGS=$(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON")
+          fi
+
+          if [ -n "$FILTERED_TAGS" ]; then
+            docker buildx imagetools create \
+              $FILTERED_TAGS \
+              ${{ needs.build.outputs.digest-amd64 }} \
+              ${{ needs.build.outputs.digest-arm64 }}
+          fi
+
+      - name: Tag with commit SHA
         run: |
           docker buildx imagetools create \
-            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            -t ${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_REPOSITORY_PROD }}:${{ steps.sha.outputs.tag }} \
             ${{ needs.build.outputs.digest-amd64 }} \
             ${{ needs.build.outputs.digest-arm64 }}
 
       - name: Setup ORAS
         uses: oras-project/setup-oras@v1
 
-      - name: Check ORAS version
-        run: oras version
-
-      - name: Determine tags to promote
-        id: promote-tags
+      - name: Login to JFrog Artifactory with ORAS
         run: |
-          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
-            VERSION=${GITHUB_REF#refs/tags/}
-            BASE_VERSION=${VERSION%}
-            echo "TAGS=latest $BASE_VERSION" >> $GITHUB_ENV
-          else
-            echo "TAGS=latest" >> $GITHUB_ENV
-          fi
+          oras login ${{ env.DOCKER_REGISTRY }} \
+            -u ${{ secrets.ARTIFACTORY_CORE_USERNAME }} \
+            -p ${{ secrets.ARTIFACTORY_CORE_TOKEN_DEVELOPER }}
 
-      - name: Login to Dockerhub registry with ORAS
+      - name: Login to Docker Hub
         run: |
           oras login ${{ env.DOCKER_PUBLIC_REGISTRY }} \
             -u ${{ secrets.DOCKER_USERNAME }} \
             -p ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Promote to Dockerhub Production
+      - name: Promote to Docker Hub Production
         run: |
-          for tag in $TAGS; do
-            echo "Current tag: $tag"
-            source_image="${DOCKER_REGISTRY}/${DOCKER_REPOSITORY_STAGING}:${tag}"
-            prod_image="${DOCKER_PUBLIC_REGISTRY}/${DOCKER_PUBLIC_REPOSITORY}:${tag}"
-            echo "Promoting ${source_image} to ${prod_image}"
-            oras cp -r "${source_image}" "${prod_image}"
+          set -e
+          SOURCE_TAG="${{ steps.tags.outputs.source_promote_tag }}"
+          echo "Tags to promote: $PROMOTE_TAGS"
+          for tag in $PROMOTE_TAGS; do
+            source_image="${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_REPOSITORY_PROD }}:${SOURCE_TAG}"
+            prod_image="${{ env.DOCKER_PUBLIC_REGISTRY }}/${{ env.DOCKER_PUBLIC_REPOSITORY }}:${tag}"
+            echo ""
+            echo "=== Promoting tag: ${tag} ==="
+            echo "Source: ${source_image}"
+            echo "Target: ${prod_image}"
+            
+            if ! oras cp -r "${source_image}" "${prod_image}"; then
+              echo "ERROR: Failed to promote tag ${tag}" >&2
+              echo "Source: ${source_image}" >&2
+              echo "Target: ${prod_image}" >&2
+              exit 1
+            fi
+            echo "✓ Successfully promoted ${tag}"
           done
+          echo ""
+          echo "All tags promoted successfully"
 
       - name: Summary
         run: |
           echo "## Catalyst Node Docker build Completed" >> $GITHUB_STEP_SUMMARY
-          echo "### Tags" >> $GITHUB_STEP_SUMMARY
-          for tag in $TAGS; do
-            echo "- $tag" >> $GITHUB_STEP_SUMMARY
-          done
-          echo "### Notes" >> $GITHUB_STEP_SUMMARY
-          echo "- The images have been pushed to ${DOCKER_REPOSITORY_STAGING} repo" >> $GITHUB_STEP_SUMMARY
-          echo "- **STAGING Repository**: ${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_REPOSITORY_STAGING }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **PROD Repository**: ${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_PUBLIC_REGISTRY }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Tags Promoted" >> $GITHUB_STEP_SUMMARY
+          
+          # Get tags from step output (more reliable than env var)
+          TAGS_STRING="${{ steps.tags.outputs.promote_tags }}"
+          
+          # If step output is empty, try environment variable
+          if [ -z "$TAGS_STRING" ]; then
+            TAGS_STRING="$PROMOTE_TAGS"
+          fi
+          
+          # Split tags by space and display each one
+          if [ -n "$TAGS_STRING" ]; then
+            # Convert space-separated string to array and iterate
+            for tag in $TAGS_STRING; do
+              echo "- \`${tag}\`" >> $GITHUB_STEP_SUMMARY
+            done
+          else
+            echo "- No tags available" >> $GITHUB_STEP_SUMMARY
+          fi
+          
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Repository Information" >> $GITHUB_STEP_SUMMARY
+          echo "- **Production**: \`${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_REPOSITORY_PROD }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- **Production**: \`${{ env.DOCKER_PUBLIC_REGISTRY }}/${{ env.DOCKER_PUBLIC_REPOSITORY }}\`" >> $GITHUB_STEP_SUMMARY
           echo "- **Platforms**: linux/amd64, linux/arm64" >> $GITHUB_STEP_SUMMARY
-          echo "- **Commit**: ${{ github.sha }}" >> $GITHUB_STEP_SUMMARY
-
+          echo "- **Commit**: \`${{ github.sha }}\` (\`${{ steps.sha.outputs.short }}\`)" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/node_docker_build.yml
+++ b/.github/workflows/node_docker_build.yml
@@ -19,7 +19,7 @@ env:
   DOCKER_PUBLIC_REGISTRY: docker.io
   DOCKER_PUBLIC_REPOSITORY: nethermind/catalyst-node
   DOCKER_REGISTRY: nethermind.jfrog.io
-  DOCKER_REPOSITORY_PROD: core-oci-local-prod/catalyst-node
+  DOCKER_REPOSITORY_STAGING: core-oci-local-staging/catalyst-node
   MASTER_BRANCH: refs/heads/master
 
 jobs:
@@ -68,7 +68,7 @@ jobs:
           push: true
           build-args: |
             BLST_PORTABLE=1
-          outputs: type=image,name=${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_REPOSITORY_PROD }},push-by-digest=true,name-canonical=true
+          outputs: type=image,name=${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_REPOSITORY_STAGING }},push-by-digest=true,name-canonical=true
 
       - name: Set digest output
         id: digest
@@ -102,12 +102,12 @@ jobs:
         id: tags
         run: |
           REF="${{ github.ref }}"
-          REALTIME_TAG="realtime-${{ steps.sha.outputs.short }}"
+          SHA_TAG="sha-${{ steps.sha.outputs.short }}"
           SOURCE_PROMOTE_TAG="${{ steps.sha.outputs.tag }}"
           IS_MASTER=false
           IS_TAG=false
           VERSION_TAG=""
-          PROMOTE_TAGS="$REALTIME_TAG"
+          PROMOTE_TAGS="$SHA_TAG"
 
           if [[ "$REF" == refs/tags/* ]]; then
             IS_TAG=true
@@ -131,7 +131,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_REPOSITORY_PROD }}
+          images: ${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_REPOSITORY_STAGING }}
           tags: ${{ steps.tags.outputs.tag_list }}
 
       - name: Create and push manifest list
@@ -153,7 +153,7 @@ jobs:
       - name: Tag with commit SHA
         run: |
           docker buildx imagetools create \
-            -t ${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_REPOSITORY_PROD }}:${{ steps.sha.outputs.tag }} \
+            -t ${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_REPOSITORY_STAGING }}:${{ steps.sha.outputs.tag }} \
             ${{ needs.build.outputs.digest-amd64 }} \
             ${{ needs.build.outputs.digest-arm64 }}
 
@@ -178,7 +178,7 @@ jobs:
           SOURCE_TAG="${{ steps.tags.outputs.source_promote_tag }}"
           echo "Tags to promote: $PROMOTE_TAGS"
           for tag in $PROMOTE_TAGS; do
-            source_image="${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_REPOSITORY_PROD }}:${SOURCE_TAG}"
+            source_image="${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_REPOSITORY_STAGING }}:${SOURCE_TAG}"
             prod_image="${{ env.DOCKER_PUBLIC_REGISTRY }}/${{ env.DOCKER_PUBLIC_REPOSITORY }}:${tag}"
             echo ""
             echo "=== Promoting tag: ${tag} ==="
@@ -222,7 +222,7 @@ jobs:
           
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Repository Information" >> $GITHUB_STEP_SUMMARY
-          echo "- **Production**: \`${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_REPOSITORY_PROD }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- **Staging**: \`${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_REPOSITORY_STAGING }}\`" >> $GITHUB_STEP_SUMMARY
           echo "- **Production**: \`${{ env.DOCKER_PUBLIC_REGISTRY }}/${{ env.DOCKER_PUBLIC_REPOSITORY }}\`" >> $GITHUB_STEP_SUMMARY
           echo "- **Platforms**: linux/amd64, linux/arm64" >> $GITHUB_STEP_SUMMARY
           echo "- **Commit**: \`${{ github.sha }}\` (\`${{ steps.sha.outputs.short }}\`)" >> $GITHUB_STEP_SUMMARY

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7099,6 +7099,7 @@ dependencies = [
 name = "realtime"
 version = "1.38.3"
 dependencies = [
+ "aes-gcm",
  "alethia-reth-consensus 0.7.1",
  "alloy",
  "alloy-json-rpc",

--- a/realtime/Cargo.toml
+++ b/realtime/Cargo.toml
@@ -20,7 +20,6 @@ fjall = { workspace = true }
 flate2 = { workspace = true }
 futures-util = { workspace = true }
 hex = { workspace = true }
-rand = "0.8"
 http = { workspace = true }
 jsonrpsee = { workspace = true }
 jsonwebtoken = { workspace = true }

--- a/realtime/Cargo.toml
+++ b/realtime/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 publish = false
 
 [dependencies]
+aes-gcm = { version = "0.10", features = ["aes"] }
 alloy = { workspace = true }
 alloy-json-rpc = { workspace = true }
 alloy-rlp = { workspace = true }
@@ -19,6 +20,7 @@ fjall = { workspace = true }
 flate2 = { workspace = true }
 futures-util = { workspace = true }
 hex = { workspace = true }
+rand = "0.8"
 http = { workspace = true }
 jsonrpsee = { workspace = true }
 jsonwebtoken = { workspace = true }

--- a/realtime/src/l1/abi/RealTimeInbox.json
+++ b/realtime/src/l1/abi/RealTimeInbox.json
@@ -1,975 +1,1179 @@
-{
-  "abi": [
-    {
-      "type": "constructor",
-      "inputs": [
-        {
-          "name": "_config",
-          "type": "tuple",
-          "internalType": "struct IRealTimeInbox.Config",
-          "components": [
-            {
-              "name": "proofVerifier",
-              "type": "address",
-              "internalType": "address"
-            },
-            {
-              "name": "signalService",
-              "type": "address",
-              "internalType": "address"
-            },
-            {
-              "name": "basefeeSharingPctg",
-              "type": "uint8",
-              "internalType": "uint8"
-            }
-          ]
-        }
-      ],
-      "stateMutability": "nonpayable"
-    },
-    {
-      "type": "function",
-      "name": "acceptOwnership",
-      "inputs": [],
-      "outputs": [],
-      "stateMutability": "nonpayable"
-    },
-    {
-      "type": "function",
-      "name": "activate",
-      "inputs": [
-        {
-          "name": "_genesisBlockHash",
-          "type": "bytes32",
-          "internalType": "bytes32"
-        }
-      ],
-      "outputs": [],
-      "stateMutability": "nonpayable"
-    },
-    {
-      "type": "function",
-      "name": "decodeProposeInput",
-      "inputs": [
-        {
-          "name": "_data",
-          "type": "bytes",
-          "internalType": "bytes"
-        }
-      ],
-      "outputs": [
-        {
-          "name": "input_",
-          "type": "tuple",
-          "internalType": "struct IRealTimeInbox.ProposeInput",
-          "components": [
-            {
-              "name": "blobReference",
-              "type": "tuple",
-              "internalType": "struct LibBlobs.BlobReference",
-              "components": [
-                {
-                  "name": "blobStartIndex",
-                  "type": "uint16",
-                  "internalType": "uint16"
-                },
-                {
-                  "name": "numBlobs",
-                  "type": "uint16",
-                  "internalType": "uint16"
-                },
-                {
-                  "name": "offset",
-                  "type": "uint24",
-                  "internalType": "uint24"
-                }
-              ]
-            },
-            {
-              "name": "signalSlots",
-              "type": "bytes32[]",
-              "internalType": "bytes32[]"
-            },
-            {
-              "name": "maxAnchorBlockNumber",
-              "type": "uint48",
-              "internalType": "uint48"
-            }
-          ]
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
-      "name": "encodeProposeInput",
-      "inputs": [
-        {
-          "name": "_input",
-          "type": "tuple",
-          "internalType": "struct IRealTimeInbox.ProposeInput",
-          "components": [
-            {
-              "name": "blobReference",
-              "type": "tuple",
-              "internalType": "struct LibBlobs.BlobReference",
-              "components": [
-                {
-                  "name": "blobStartIndex",
-                  "type": "uint16",
-                  "internalType": "uint16"
-                },
-                {
-                  "name": "numBlobs",
-                  "type": "uint16",
-                  "internalType": "uint16"
-                },
-                {
-                  "name": "offset",
-                  "type": "uint24",
-                  "internalType": "uint24"
-                }
-              ]
-            },
-            {
-              "name": "signalSlots",
-              "type": "bytes32[]",
-              "internalType": "bytes32[]"
-            },
-            {
-              "name": "maxAnchorBlockNumber",
-              "type": "uint48",
-              "internalType": "uint48"
-            }
-          ]
-        }
-      ],
-      "outputs": [
-        {
-          "name": "encoded_",
-          "type": "bytes",
-          "internalType": "bytes"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
-      "name": "finalizePropose",
-      "inputs": [
-        {
-          "name": "_requiredReturnSignals",
-          "type": "bytes32[]",
-          "internalType": "bytes32[]"
-        }
-      ],
-      "outputs": [],
-      "stateMutability": "nonpayable"
-    },
-    {
-      "type": "function",
-      "name": "getConfig",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "config_",
-          "type": "tuple",
-          "internalType": "struct IRealTimeInbox.Config",
-          "components": [
-            {
-              "name": "proofVerifier",
-              "type": "address",
-              "internalType": "address"
-            },
-            {
-              "name": "signalService",
-              "type": "address",
-              "internalType": "address"
-            },
-            {
-              "name": "basefeeSharingPctg",
-              "type": "uint8",
-              "internalType": "uint8"
-            }
-          ]
-        }
-      ],
-      "stateMutability": "view"
-    },
-    {
-      "type": "function",
-      "name": "getLastFinalizedBlockHash",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "",
-          "type": "bytes32",
-          "internalType": "bytes32"
-        }
-      ],
-      "stateMutability": "view"
-    },
-    {
-      "type": "function",
-      "name": "hashCommitment",
-      "inputs": [
-        {
-          "name": "_commitment",
-          "type": "tuple",
-          "internalType": "struct IRealTimeInbox.Commitment",
-          "components": [
-            {
-              "name": "proposalHash",
-              "type": "bytes32",
-              "internalType": "bytes32"
-            },
-            {
-              "name": "lastFinalizedBlockHash",
-              "type": "bytes32",
-              "internalType": "bytes32"
-            },
-            {
-              "name": "checkpoint",
-              "type": "tuple",
-              "internalType": "struct ICheckpointStore.Checkpoint",
-              "components": [
-                {
-                  "name": "blockNumber",
-                  "type": "uint48",
-                  "internalType": "uint48"
-                },
-                {
-                  "name": "blockHash",
-                  "type": "bytes32",
-                  "internalType": "bytes32"
-                },
-                {
-                  "name": "stateRoot",
-                  "type": "bytes32",
-                  "internalType": "bytes32"
-                }
-              ]
-            }
-          ]
-        }
-      ],
-      "outputs": [
-        {
-          "name": "",
-          "type": "bytes32",
-          "internalType": "bytes32"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
-      "name": "hashProposal",
-      "inputs": [
-        {
-          "name": "_proposal",
-          "type": "tuple",
-          "internalType": "struct IRealTimeInbox.Proposal",
-          "components": [
-            {
-              "name": "maxAnchorBlockNumber",
-              "type": "uint48",
-              "internalType": "uint48"
-            },
-            {
-              "name": "maxAnchorBlockHash",
-              "type": "bytes32",
-              "internalType": "bytes32"
-            },
-            {
-              "name": "basefeeSharingPctg",
-              "type": "uint8",
-              "internalType": "uint8"
-            },
-            {
-              "name": "sources",
-              "type": "tuple[]",
-              "internalType": "struct IInbox.DerivationSource[]",
-              "components": [
-                {
-                  "name": "isForcedInclusion",
-                  "type": "bool",
-                  "internalType": "bool"
-                },
-                {
-                  "name": "blobSlice",
-                  "type": "tuple",
-                  "internalType": "struct LibBlobs.BlobSlice",
-                  "components": [
-                    {
-                      "name": "blobHashes",
-                      "type": "bytes32[]",
-                      "internalType": "bytes32[]"
-                    },
-                    {
-                      "name": "offset",
-                      "type": "uint24",
-                      "internalType": "uint24"
-                    },
-                    {
-                      "name": "timestamp",
-                      "type": "uint48",
-                      "internalType": "uint48"
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "name": "signalSlotsHash",
-              "type": "bytes32",
-              "internalType": "bytes32"
-            }
-          ]
-        }
-      ],
-      "outputs": [
-        {
-          "name": "",
-          "type": "bytes32",
-          "internalType": "bytes32"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
-      "name": "hashSignalSlots",
-      "inputs": [
-        {
-          "name": "_signalSlots",
-          "type": "bytes32[]",
-          "internalType": "bytes32[]"
-        }
-      ],
-      "outputs": [
-        {
-          "name": "",
-          "type": "bytes32",
-          "internalType": "bytes32"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
-      "name": "impl",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "",
-          "type": "address",
-          "internalType": "address"
-        }
-      ],
-      "stateMutability": "view"
-    },
-    {
-      "type": "function",
-      "name": "inNonReentrant",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "",
-          "type": "bool",
-          "internalType": "bool"
-        }
-      ],
-      "stateMutability": "view"
-    },
-    {
-      "type": "function",
-      "name": "init",
-      "inputs": [
-        {
-          "name": "_owner",
-          "type": "address",
-          "internalType": "address"
-        }
-      ],
-      "outputs": [],
-      "stateMutability": "nonpayable"
-    },
-    {
-      "type": "function",
-      "name": "lastFinalizedBlockHash",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "",
-          "type": "bytes32",
-          "internalType": "bytes32"
-        }
-      ],
-      "stateMutability": "view"
-    },
-    {
-      "type": "function",
-      "name": "owner",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "",
-          "type": "address",
-          "internalType": "address"
-        }
-      ],
-      "stateMutability": "view"
-    },
-    {
-      "type": "function",
-      "name": "pause",
-      "inputs": [],
-      "outputs": [],
-      "stateMutability": "nonpayable"
-    },
-    {
-      "type": "function",
-      "name": "paused",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "",
-          "type": "bool",
-          "internalType": "bool"
-        }
-      ],
-      "stateMutability": "view"
-    },
-    {
-      "type": "function",
-      "name": "pendingOwner",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "",
-          "type": "address",
-          "internalType": "address"
-        }
-      ],
-      "stateMutability": "view"
-    },
-    {
-      "type": "function",
-      "name": "propose",
-      "inputs": [
-        {
-          "name": "_data",
-          "type": "bytes",
-          "internalType": "bytes"
-        },
-        {
-          "name": "_checkpoint",
-          "type": "tuple",
-          "internalType": "struct ICheckpointStore.Checkpoint",
-          "components": [
-            {
-              "name": "blockNumber",
-              "type": "uint48",
-              "internalType": "uint48"
-            },
-            {
-              "name": "blockHash",
-              "type": "bytes32",
-              "internalType": "bytes32"
-            },
-            {
-              "name": "stateRoot",
-              "type": "bytes32",
-              "internalType": "bytes32"
-            }
-          ]
-        },
-        {
-          "name": "_proof",
-          "type": "bytes",
-          "internalType": "bytes"
-        }
-      ],
-      "outputs": [],
-      "stateMutability": "nonpayable"
-    },
-    {
-      "type": "function",
-      "name": "proxiableUUID",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "",
-          "type": "bytes32",
-          "internalType": "bytes32"
-        }
-      ],
-      "stateMutability": "view"
-    },
-    {
-      "type": "function",
-      "name": "renounceOwnership",
-      "inputs": [],
-      "outputs": [],
-      "stateMutability": "nonpayable"
-    },
-    {
-      "type": "function",
-      "name": "resolver",
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "",
-          "type": "address",
-          "internalType": "address"
-        }
-      ],
-      "stateMutability": "view"
-    },
-    {
-      "type": "function",
-      "name": "tentativePropose",
-      "inputs": [
-        {
-          "name": "_data",
-          "type": "bytes",
-          "internalType": "bytes"
-        },
-        {
-          "name": "_checkpoint",
-          "type": "tuple",
-          "internalType": "struct ICheckpointStore.Checkpoint",
-          "components": [
-            {
-              "name": "blockNumber",
-              "type": "uint48",
-              "internalType": "uint48"
-            },
-            {
-              "name": "blockHash",
-              "type": "bytes32",
-              "internalType": "bytes32"
-            },
-            {
-              "name": "stateRoot",
-              "type": "bytes32",
-              "internalType": "bytes32"
-            }
-          ]
-        },
-        {
-          "name": "_proof",
-          "type": "bytes",
-          "internalType": "bytes"
-        }
-      ],
-      "outputs": [
-        {
-          "name": "proposalId_",
-          "type": "bytes32",
-          "internalType": "bytes32"
-        }
-      ],
-      "stateMutability": "nonpayable"
-    },
-    {
-      "type": "function",
-      "name": "transferOwnership",
-      "inputs": [
-        {
-          "name": "newOwner",
-          "type": "address",
-          "internalType": "address"
-        }
-      ],
-      "outputs": [],
-      "stateMutability": "nonpayable"
-    },
-    {
-      "type": "function",
-      "name": "unpause",
-      "inputs": [],
-      "outputs": [],
-      "stateMutability": "nonpayable"
-    },
-    {
-      "type": "function",
-      "name": "upgradeTo",
-      "inputs": [
-        {
-          "name": "newImplementation",
-          "type": "address",
-          "internalType": "address"
-        }
-      ],
-      "outputs": [],
-      "stateMutability": "nonpayable"
-    },
-    {
-      "type": "function",
-      "name": "upgradeToAndCall",
-      "inputs": [
-        {
-          "name": "newImplementation",
-          "type": "address",
-          "internalType": "address"
-        },
-        {
-          "name": "data",
-          "type": "bytes",
-          "internalType": "bytes"
-        }
-      ],
-      "outputs": [],
-      "stateMutability": "payable"
-    },
-    {
-      "type": "event",
-      "name": "Activated",
-      "inputs": [
-        {
-          "name": "genesisBlockHash",
-          "type": "bytes32",
-          "indexed": false,
-          "internalType": "bytes32"
-        }
-      ],
-      "anonymous": false
-    },
-    {
-      "type": "event",
-      "name": "AdminChanged",
-      "inputs": [
-        {
-          "name": "previousAdmin",
-          "type": "address",
-          "indexed": false,
-          "internalType": "address"
-        },
-        {
-          "name": "newAdmin",
-          "type": "address",
-          "indexed": false,
-          "internalType": "address"
-        }
-      ],
-      "anonymous": false
-    },
-    {
-      "type": "event",
-      "name": "BeaconUpgraded",
-      "inputs": [
-        {
-          "name": "beacon",
-          "type": "address",
-          "indexed": true,
-          "internalType": "address"
-        }
-      ],
-      "anonymous": false
-    },
-    {
-      "type": "event",
-      "name": "Initialized",
-      "inputs": [
-        {
-          "name": "version",
-          "type": "uint8",
-          "indexed": false,
-          "internalType": "uint8"
-        }
-      ],
-      "anonymous": false
-    },
-    {
-      "type": "event",
-      "name": "OwnershipTransferStarted",
-      "inputs": [
-        {
-          "name": "previousOwner",
-          "type": "address",
-          "indexed": true,
-          "internalType": "address"
-        },
-        {
-          "name": "newOwner",
-          "type": "address",
-          "indexed": true,
-          "internalType": "address"
-        }
-      ],
-      "anonymous": false
-    },
-    {
-      "type": "event",
-      "name": "OwnershipTransferred",
-      "inputs": [
-        {
-          "name": "previousOwner",
-          "type": "address",
-          "indexed": true,
-          "internalType": "address"
-        },
-        {
-          "name": "newOwner",
-          "type": "address",
-          "indexed": true,
-          "internalType": "address"
-        }
-      ],
-      "anonymous": false
-    },
-    {
-      "type": "event",
-      "name": "Paused",
-      "inputs": [
-        {
-          "name": "account",
-          "type": "address",
-          "indexed": false,
-          "internalType": "address"
-        }
-      ],
-      "anonymous": false
-    },
-    {
-      "type": "event",
-      "name": "ProposedAndProved",
-      "inputs": [
-        {
-          "name": "proposalHash",
-          "type": "bytes32",
-          "indexed": true,
-          "internalType": "bytes32"
-        },
-        {
-          "name": "lastFinalizedBlockHash",
-          "type": "bytes32",
-          "indexed": false,
-          "internalType": "bytes32"
-        },
-        {
-          "name": "maxAnchorBlockNumber",
-          "type": "uint48",
-          "indexed": false,
-          "internalType": "uint48"
-        },
-        {
-          "name": "basefeeSharingPctg",
-          "type": "uint8",
-          "indexed": false,
-          "internalType": "uint8"
-        },
-        {
-          "name": "sources",
-          "type": "tuple[]",
-          "indexed": false,
-          "internalType": "struct IInbox.DerivationSource[]",
-          "components": [
-            {
-              "name": "isForcedInclusion",
-              "type": "bool",
-              "internalType": "bool"
-            },
-            {
-              "name": "blobSlice",
-              "type": "tuple",
-              "internalType": "struct LibBlobs.BlobSlice",
-              "components": [
-                {
-                  "name": "blobHashes",
-                  "type": "bytes32[]",
-                  "internalType": "bytes32[]"
-                },
-                {
-                  "name": "offset",
-                  "type": "uint24",
-                  "internalType": "uint24"
-                },
-                {
-                  "name": "timestamp",
-                  "type": "uint48",
-                  "internalType": "uint48"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "signalSlots",
-          "type": "bytes32[]",
-          "indexed": false,
-          "internalType": "bytes32[]"
-        },
-        {
-          "name": "checkpoint",
-          "type": "tuple",
-          "indexed": false,
-          "internalType": "struct ICheckpointStore.Checkpoint",
-          "components": [
-            {
-              "name": "blockNumber",
-              "type": "uint48",
-              "internalType": "uint48"
-            },
-            {
-              "name": "blockHash",
-              "type": "bytes32",
-              "internalType": "bytes32"
-            },
-            {
-              "name": "stateRoot",
-              "type": "bytes32",
-              "internalType": "bytes32"
-            }
-          ]
-        }
-      ],
-      "anonymous": false
-    },
-    {
-      "type": "event",
-      "name": "TentativeProposed",
-      "inputs": [
-        {
-          "name": "proposalId",
-          "type": "bytes32",
-          "indexed": true,
-          "internalType": "bytes32"
-        },
-        {
-          "name": "requiredReturnSignalsHash",
-          "type": "bytes32",
-          "indexed": false,
-          "internalType": "bytes32"
-        }
-      ],
-      "anonymous": false
-    },
-    {
-      "type": "event",
-      "name": "Unpaused",
-      "inputs": [
-        {
-          "name": "account",
-          "type": "address",
-          "indexed": false,
-          "internalType": "address"
-        }
-      ],
-      "anonymous": false
-    },
-    {
-      "type": "event",
-      "name": "Upgraded",
-      "inputs": [
-        {
-          "name": "implementation",
-          "type": "address",
-          "indexed": true,
-          "internalType": "address"
-        }
-      ],
-      "anonymous": false
-    },
-    {
-      "type": "error",
-      "name": "ACCESS_DENIED",
-      "inputs": []
-    },
-    {
-      "type": "error",
-      "name": "AlreadyActivated",
-      "inputs": []
-    },
-    {
-      "type": "error",
-      "name": "BlobNotFound",
-      "inputs": []
-    },
-    {
-      "type": "error",
-      "name": "FUNC_NOT_IMPLEMENTED",
-      "inputs": []
-    },
-    {
-      "type": "error",
-      "name": "INVALID_PAUSE_STATUS",
-      "inputs": []
-    },
-    {
-      "type": "error",
-      "name": "InvalidGenesisBlockHash",
-      "inputs": []
-    },
-    {
-      "type": "error",
-      "name": "MaxAnchorBlockTooOld",
-      "inputs": []
-    },
-    {
-      "type": "error",
-      "name": "NoBlobs",
-      "inputs": []
-    },
-    {
-      "type": "error",
-      "name": "NoPendingProposal",
-      "inputs": []
-    },
-    {
-      "type": "error",
-      "name": "NotActivated",
-      "inputs": []
-    },
-    {
-      "type": "error",
-      "name": "PendingProposalAlreadyExists",
-      "inputs": []
-    },
-    {
-      "type": "error",
-      "name": "REENTRANT_CALL",
-      "inputs": []
-    },
-    {
-      "type": "error",
-      "name": "RequiredSignalNotSent",
-      "inputs": [
-        {
-          "name": "slot",
-          "type": "bytes32",
-          "internalType": "bytes32"
-        }
-      ]
-    },
-    {
-      "type": "error",
-      "name": "RequiredSignalsMismatch",
-      "inputs": []
-    },
-    {
-      "type": "error",
-      "name": "SignalSlotNotSent",
-      "inputs": [
-        {
-          "name": "slot",
-          "type": "bytes32",
-          "internalType": "bytes32"
-        }
-      ]
-    },
-    {
-      "type": "error",
-      "name": "ZERO_ADDRESS",
-      "inputs": []
-    },
-    {
-      "type": "error",
-      "name": "ZERO_VALUE",
-      "inputs": []
-    }
-  ]
-}
+[
+  {
+    "type": "constructor",
+    "inputs": [
+      {
+        "name": "_config",
+        "type": "tuple",
+        "internalType": "struct IRealTimeInbox.Config",
+        "components": [
+          {
+            "name": "proofVerifier",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "signalService",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "basefeeSharingPctg",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "forcedInclusionDelay",
+            "type": "uint16",
+            "internalType": "uint16"
+          },
+          {
+            "name": "forcedInclusionFeeInGwei",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "forcedInclusionFeeDoubleThreshold",
+            "type": "uint64",
+            "internalType": "uint64"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "acceptOwnership",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "activate",
+    "inputs": [
+      {
+        "name": "_genesisBlockHash",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "decodeProposeInput",
+    "inputs": [
+      {
+        "name": "_data",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "input_",
+        "type": "tuple",
+        "internalType": "struct IRealTimeInbox.ProposeInput",
+        "components": [
+          {
+            "name": "blobReference",
+            "type": "tuple",
+            "internalType": "struct LibBlobs.BlobReference",
+            "components": [
+              {
+                "name": "blobStartIndex",
+                "type": "uint16",
+                "internalType": "uint16"
+              },
+              {
+                "name": "numBlobs",
+                "type": "uint16",
+                "internalType": "uint16"
+              },
+              {
+                "name": "offset",
+                "type": "uint24",
+                "internalType": "uint24"
+              }
+            ]
+          },
+          {
+            "name": "numForcedInclusions",
+            "type": "uint16",
+            "internalType": "uint16"
+          },
+          {
+            "name": "signalSlots",
+            "type": "bytes32[]",
+            "internalType": "bytes32[]"
+          },
+          {
+            "name": "maxAnchorBlockNumber",
+            "type": "uint48",
+            "internalType": "uint48"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "encodeProposeInput",
+    "inputs": [
+      {
+        "name": "_input",
+        "type": "tuple",
+        "internalType": "struct IRealTimeInbox.ProposeInput",
+        "components": [
+          {
+            "name": "blobReference",
+            "type": "tuple",
+            "internalType": "struct LibBlobs.BlobReference",
+            "components": [
+              {
+                "name": "blobStartIndex",
+                "type": "uint16",
+                "internalType": "uint16"
+              },
+              {
+                "name": "numBlobs",
+                "type": "uint16",
+                "internalType": "uint16"
+              },
+              {
+                "name": "offset",
+                "type": "uint24",
+                "internalType": "uint24"
+              }
+            ]
+          },
+          {
+            "name": "numForcedInclusions",
+            "type": "uint16",
+            "internalType": "uint16"
+          },
+          {
+            "name": "signalSlots",
+            "type": "bytes32[]",
+            "internalType": "bytes32[]"
+          },
+          {
+            "name": "maxAnchorBlockNumber",
+            "type": "uint48",
+            "internalType": "uint48"
+          }
+        ]
+      }
+    ],
+    "outputs": [
+      {
+        "name": "encoded_",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "finalizePropose",
+    "inputs": [
+      {
+        "name": "_requiredReturnSignals",
+        "type": "bytes32[]",
+        "internalType": "bytes32[]"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "getConfig",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "config_",
+        "type": "tuple",
+        "internalType": "struct IRealTimeInbox.Config",
+        "components": [
+          {
+            "name": "proofVerifier",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "signalService",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "basefeeSharingPctg",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "forcedInclusionDelay",
+            "type": "uint16",
+            "internalType": "uint16"
+          },
+          {
+            "name": "forcedInclusionFeeInGwei",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "forcedInclusionFeeDoubleThreshold",
+            "type": "uint64",
+            "internalType": "uint64"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getCurrentForcedInclusionFee",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "feeInGwei_",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getForcedInclusionState",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "head_",
+        "type": "uint48",
+        "internalType": "uint48"
+      },
+      {
+        "name": "tail_",
+        "type": "uint48",
+        "internalType": "uint48"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getForcedInclusions",
+    "inputs": [
+      {
+        "name": "_start",
+        "type": "uint48",
+        "internalType": "uint48"
+      },
+      {
+        "name": "_maxCount",
+        "type": "uint48",
+        "internalType": "uint48"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "inclusions_",
+        "type": "tuple[]",
+        "internalType": "struct IForcedInclusionStore.ForcedInclusion[]",
+        "components": [
+          {
+            "name": "feeInGwei",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "blobSlice",
+            "type": "tuple",
+            "internalType": "struct LibBlobs.BlobSlice",
+            "components": [
+              {
+                "name": "blobHashes",
+                "type": "bytes32[]",
+                "internalType": "bytes32[]"
+              },
+              {
+                "name": "offset",
+                "type": "uint24",
+                "internalType": "uint24"
+              },
+              {
+                "name": "timestamp",
+                "type": "uint48",
+                "internalType": "uint48"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getLastFinalizedBlockHash",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "hashCommitment",
+    "inputs": [
+      {
+        "name": "_commitment",
+        "type": "tuple",
+        "internalType": "struct IRealTimeInbox.Commitment",
+        "components": [
+          {
+            "name": "proposalHash",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "lastFinalizedBlockHash",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "checkpoint",
+            "type": "tuple",
+            "internalType": "struct ICheckpointStore.Checkpoint",
+            "components": [
+              {
+                "name": "blockNumber",
+                "type": "uint48",
+                "internalType": "uint48"
+              },
+              {
+                "name": "blockHash",
+                "type": "bytes32",
+                "internalType": "bytes32"
+              },
+              {
+                "name": "stateRoot",
+                "type": "bytes32",
+                "internalType": "bytes32"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "hashProposal",
+    "inputs": [
+      {
+        "name": "_proposal",
+        "type": "tuple",
+        "internalType": "struct IRealTimeInbox.Proposal",
+        "components": [
+          {
+            "name": "maxAnchorBlockNumber",
+            "type": "uint48",
+            "internalType": "uint48"
+          },
+          {
+            "name": "maxAnchorBlockHash",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "basefeeSharingPctg",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "sources",
+            "type": "tuple[]",
+            "internalType": "struct IInbox.DerivationSource[]",
+            "components": [
+              {
+                "name": "isForcedInclusion",
+                "type": "bool",
+                "internalType": "bool"
+              },
+              {
+                "name": "blobSlice",
+                "type": "tuple",
+                "internalType": "struct LibBlobs.BlobSlice",
+                "components": [
+                  {
+                    "name": "blobHashes",
+                    "type": "bytes32[]",
+                    "internalType": "bytes32[]"
+                  },
+                  {
+                    "name": "offset",
+                    "type": "uint24",
+                    "internalType": "uint24"
+                  },
+                  {
+                    "name": "timestamp",
+                    "type": "uint48",
+                    "internalType": "uint48"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "signalSlotsHash",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          }
+        ]
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "hashSignalSlots",
+    "inputs": [
+      {
+        "name": "_signalSlots",
+        "type": "bytes32[]",
+        "internalType": "bytes32[]"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "impl",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "inNonReentrant",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "init",
+    "inputs": [
+      {
+        "name": "_owner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "lastFinalizedBlockHash",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "owner",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "pause",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "paused",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "pendingOwner",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "propose",
+    "inputs": [
+      {
+        "name": "_data",
+        "type": "bytes",
+        "internalType": "bytes"
+      },
+      {
+        "name": "_checkpoint",
+        "type": "tuple",
+        "internalType": "struct ICheckpointStore.Checkpoint",
+        "components": [
+          {
+            "name": "blockNumber",
+            "type": "uint48",
+            "internalType": "uint48"
+          },
+          {
+            "name": "blockHash",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "stateRoot",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          }
+        ]
+      },
+      {
+        "name": "_proof",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "proxiableUUID",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "renounceOwnership",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "resolver",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "saveForcedInclusion",
+    "inputs": [
+      {
+        "name": "_blobReference",
+        "type": "tuple",
+        "internalType": "struct LibBlobs.BlobReference",
+        "components": [
+          {
+            "name": "blobStartIndex",
+            "type": "uint16",
+            "internalType": "uint16"
+          },
+          {
+            "name": "numBlobs",
+            "type": "uint16",
+            "internalType": "uint16"
+          },
+          {
+            "name": "offset",
+            "type": "uint24",
+            "internalType": "uint24"
+          }
+        ]
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "tentativePropose",
+    "inputs": [
+      {
+        "name": "_data",
+        "type": "bytes",
+        "internalType": "bytes"
+      },
+      {
+        "name": "_checkpoint",
+        "type": "tuple",
+        "internalType": "struct ICheckpointStore.Checkpoint",
+        "components": [
+          {
+            "name": "blockNumber",
+            "type": "uint48",
+            "internalType": "uint48"
+          },
+          {
+            "name": "blockHash",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "stateRoot",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          }
+        ]
+      },
+      {
+        "name": "_proof",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "proposalId_",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "transferOwnership",
+    "inputs": [
+      {
+        "name": "newOwner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "unpause",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "upgradeTo",
+    "inputs": [
+      {
+        "name": "newImplementation",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "upgradeToAndCall",
+    "inputs": [
+      {
+        "name": "newImplementation",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "data",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "event",
+    "name": "Activated",
+    "inputs": [
+      {
+        "name": "genesisBlockHash",
+        "type": "bytes32",
+        "indexed": false,
+        "internalType": "bytes32"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "AdminChanged",
+    "inputs": [
+      {
+        "name": "previousAdmin",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      },
+      {
+        "name": "newAdmin",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "BeaconUpgraded",
+    "inputs": [
+      {
+        "name": "beacon",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ForcedInclusionSaved",
+    "inputs": [
+      {
+        "name": "forcedInclusion",
+        "type": "tuple",
+        "indexed": false,
+        "internalType": "struct IForcedInclusionStore.ForcedInclusion",
+        "components": [
+          {
+            "name": "feeInGwei",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "blobSlice",
+            "type": "tuple",
+            "internalType": "struct LibBlobs.BlobSlice",
+            "components": [
+              {
+                "name": "blobHashes",
+                "type": "bytes32[]",
+                "internalType": "bytes32[]"
+              },
+              {
+                "name": "offset",
+                "type": "uint24",
+                "internalType": "uint24"
+              },
+              {
+                "name": "timestamp",
+                "type": "uint48",
+                "internalType": "uint48"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Initialized",
+    "inputs": [
+      {
+        "name": "version",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "uint8"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "OwnershipTransferStarted",
+    "inputs": [
+      {
+        "name": "previousOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "newOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "OwnershipTransferred",
+    "inputs": [
+      {
+        "name": "previousOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "newOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Paused",
+    "inputs": [
+      {
+        "name": "account",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ProposedAndProved",
+    "inputs": [
+      {
+        "name": "proposalHash",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "lastFinalizedBlockHash",
+        "type": "bytes32",
+        "indexed": false,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "maxAnchorBlockNumber",
+        "type": "uint48",
+        "indexed": false,
+        "internalType": "uint48"
+      },
+      {
+        "name": "basefeeSharingPctg",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "uint8"
+      },
+      {
+        "name": "sources",
+        "type": "tuple[]",
+        "indexed": false,
+        "internalType": "struct IInbox.DerivationSource[]",
+        "components": [
+          {
+            "name": "isForcedInclusion",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "blobSlice",
+            "type": "tuple",
+            "internalType": "struct LibBlobs.BlobSlice",
+            "components": [
+              {
+                "name": "blobHashes",
+                "type": "bytes32[]",
+                "internalType": "bytes32[]"
+              },
+              {
+                "name": "offset",
+                "type": "uint24",
+                "internalType": "uint24"
+              },
+              {
+                "name": "timestamp",
+                "type": "uint48",
+                "internalType": "uint48"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "signalSlots",
+        "type": "bytes32[]",
+        "indexed": false,
+        "internalType": "bytes32[]"
+      },
+      {
+        "name": "checkpoint",
+        "type": "tuple",
+        "indexed": false,
+        "internalType": "struct ICheckpointStore.Checkpoint",
+        "components": [
+          {
+            "name": "blockNumber",
+            "type": "uint48",
+            "internalType": "uint48"
+          },
+          {
+            "name": "blockHash",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "stateRoot",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          }
+        ]
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "TentativeProposed",
+    "inputs": [
+      {
+        "name": "proposalId",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "requiredReturnSignalsHash",
+        "type": "bytes32",
+        "indexed": false,
+        "internalType": "bytes32"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Unpaused",
+    "inputs": [
+      {
+        "name": "account",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Upgraded",
+    "inputs": [
+      {
+        "name": "implementation",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "error",
+    "name": "ACCESS_DENIED",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "AlreadyActivated",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "BlobNotFound",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ETH_TRANSFER_FAILED",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "FUNC_NOT_IMPLEMENTED",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "INVALID_PAUSE_STATUS",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidGenesisBlockHash",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "MaxAnchorBlockTooOld",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NoBlobs",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NoPendingProposal",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotActivated",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "PendingProposalAlreadyExists",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "REENTRANT_CALL",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "RequiredSignalNotSent",
+    "inputs": [
+      {
+        "name": "slot",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "RequiredSignalsMismatch",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "SignalSlotNotSent",
+    "inputs": [
+      {
+        "name": "slot",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "UnprocessedForcedInclusionIsDue",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZERO_ADDRESS",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZERO_VALUE",
+    "inputs": []
+  }
+]

--- a/realtime/src/l1/bindings.rs
+++ b/realtime/src/l1/bindings.rs
@@ -30,6 +30,7 @@ sol! {
 
     struct ProposeInput {
         BlobReference blobReference;
+        uint16 numForcedInclusions;
         bytes32[] signalSlots;
         uint48 maxAnchorBlockNumber;
     }
@@ -39,6 +40,7 @@ sol! {
     /// L1 callback in the same multicall produces them).
     struct ProposeInputV2 {
         BlobReference blobReference;
+        uint16 numForcedInclusions;
         bytes32[] existingSignals;
         bytes32[] requiredReturnSignals;
         uint48 maxAnchorBlockNumber;

--- a/realtime/src/l1/config.rs
+++ b/realtime/src/l1/config.rs
@@ -15,6 +15,9 @@ pub struct EthereumL1Config {
     pub bridge: Address,
     pub proof_type: ProofType,
     pub mock_mode: bool,
+    pub privacy_mode: bool,
+    pub privacy_symmetric_key: Option<[u8; 32]>,
+    pub fi_max_per_proposal: u16,
 }
 
 impl TryFrom<RealtimeConfig> for EthereumL1Config {
@@ -27,6 +30,9 @@ impl TryFrom<RealtimeConfig> for EthereumL1Config {
             bridge: config.bridge,
             proof_type: config.proof_type,
             mock_mode: config.mock_mode,
+            privacy_mode: config.privacy_mode,
+            privacy_symmetric_key: config.privacy_symmetric_key,
+            fi_max_per_proposal: config.fi_max_per_proposal,
         })
     }
 }

--- a/realtime/src/l1/execution_layer.rs
+++ b/realtime/src/l1/execution_layer.rs
@@ -105,7 +105,10 @@ impl ELTrait for ExecutionLayer {
         let mock_mode = specific_config.mock_mode;
         let extra_gas_percentage = common_config.extra_gas_percentage;
 
-        let proposal_cipher = match (specific_config.privacy_mode, specific_config.privacy_symmetric_key) {
+        let proposal_cipher = match (
+            specific_config.privacy_mode,
+            specific_config.privacy_symmetric_key,
+        ) {
             (true, Some(key)) => crate::privacy::ProposalCipher::enabled(key),
             (true, None) => {
                 return Err(anyhow!(
@@ -240,17 +243,21 @@ impl ExecutionLayer {
         // FI (one whose timestamp + forcedInclusionDelay has passed) — so if the
         // due-count exceeds the cap, the propose call will revert and the
         // operator must increase the cap.
-        let (head, tail) = match self.get_forced_inclusion_state().await {
-            Ok(state) => state,
-            Err(e) => {
-                tracing::warn!(
-                    "Failed to read forced-inclusion state, proceeding with 0: {e}"
-                );
-                (0, 0)
-            }
-        };
+        //
+        // If the FI-state RPC fails, we error out and skip this slot rather than
+        // proceed with `numForcedInclusions = 0`: when there are actually due
+        // forced inclusions, the on-chain `propose` call would revert with
+        // `UnprocessedForcedInclusionIsDue`, burning blob-tx gas. Skipping the
+        // slot preserves the chain's progression and lets the next tick retry.
+        let (head, tail) = self
+            .get_forced_inclusion_state()
+            .await
+            .map_err(|e| anyhow!("FI-state RPC failed; skipping propose for this slot: {e}"))?;
         let pending = tail.saturating_sub(head);
-        let num_forced_inclusions = pending.min(u64::from(self.fi_max_per_proposal)) as u16;
+        // Bounded by `fi_max_per_proposal: u16`, so the truncating cast would be
+        // safe — but `cast_possible_truncation` is workspace-deny, so use try_from.
+        let num_forced_inclusions = u16::try_from(pending.min(u64::from(self.fi_max_per_proposal)))
+            .unwrap_or(self.fi_max_per_proposal);
         if num_forced_inclusions > 0 {
             info!(
                 "Consuming {num_forced_inclusions} forced inclusion(s) (queue head={head}, tail={tail})"

--- a/realtime/src/l1/execution_layer.rs
+++ b/realtime/src/l1/execution_layer.rs
@@ -47,6 +47,8 @@ pub struct ExecutionLayer {
     proof_type: crate::l1::bindings::ProofType,
     mock_mode: bool,
     extra_gas_percentage: u64,
+    proposal_cipher: crate::privacy::ProposalCipher,
+    fi_max_per_proposal: u16,
 }
 
 impl ELTrait for ExecutionLayer {
@@ -103,6 +105,21 @@ impl ELTrait for ExecutionLayer {
         let mock_mode = specific_config.mock_mode;
         let extra_gas_percentage = common_config.extra_gas_percentage;
 
+        let proposal_cipher = match (specific_config.privacy_mode, specific_config.privacy_symmetric_key) {
+            (true, Some(key)) => crate::privacy::ProposalCipher::enabled(key),
+            (true, None) => {
+                return Err(anyhow!(
+                    "SURGE_PRIVACY_MODE=true but no SURGE_PRIVACY_SYMMETRIC_KEY configured"
+                ));
+            }
+            (false, _) => crate::privacy::ProposalCipher::disabled(),
+        };
+        if proposal_cipher.is_enabled() {
+            tracing::info!("Proposal blob privacy mode: enabled (AES-256-GCM, scheme 0x01)");
+        } else {
+            tracing::info!("Proposal blob privacy mode: disabled (scheme 0x00)");
+        }
+
         Ok(Self {
             common,
             provider,
@@ -113,11 +130,33 @@ impl ELTrait for ExecutionLayer {
             proof_type,
             mock_mode,
             extra_gas_percentage,
+            proposal_cipher,
+            fi_max_per_proposal: specific_config.fi_max_per_proposal,
         })
     }
 
     fn common(&self) -> &ExecutionLayerCommon {
         &self.common
+    }
+}
+
+impl ExecutionLayer {
+    /// Cipher used to wrap compressed manifests before they become blob payloads.
+    /// Cheap to clone (just an `Option<[u8; 32]>`).
+    pub fn proposal_cipher(&self) -> crate::privacy::ProposalCipher {
+        self.proposal_cipher.clone()
+    }
+
+    /// Reads the FI queue head/tail from the RealTimeInbox. Used by the proposer to
+    /// decide how many forced inclusions to consume in the next proposal.
+    pub async fn get_forced_inclusion_state(&self) -> Result<(u64, u64), Error> {
+        let res = self
+            .realtime_inbox
+            .getForcedInclusionState()
+            .call()
+            .await
+            .map_err(|e| anyhow!("getForcedInclusionState failed: {e}"))?;
+        Ok((res.head_.to::<u64>(), res.tail_.to::<u64>()))
     }
 }
 
@@ -196,11 +235,34 @@ impl ExecutionLayer {
             batch.zk_proof.is_some(),
         );
 
+        // Decide how many forced inclusions to consume from the queue. Capped by
+        // `fi_max_per_proposal`; the contract enforces consumption of any "due"
+        // FI (one whose timestamp + forcedInclusionDelay has passed) — so if the
+        // due-count exceeds the cap, the propose call will revert and the
+        // operator must increase the cap.
+        let (head, tail) = match self.get_forced_inclusion_state().await {
+            Ok(state) => state,
+            Err(e) => {
+                tracing::warn!(
+                    "Failed to read forced-inclusion state, proceeding with 0: {e}"
+                );
+                (0, 0)
+            }
+        };
+        let pending = tail.saturating_sub(head);
+        let num_forced_inclusions = pending.min(u64::from(self.fi_max_per_proposal)) as u16;
+        if num_forced_inclusions > 0 {
+            info!(
+                "Consuming {num_forced_inclusions} forced inclusion(s) (queue head={head}, tail={tail})"
+            );
+        }
+
         let builder = ProposalTxBuilder::new(
             self.provider.clone(),
             self.extra_gas_percentage,
             self.proof_type,
             self.mock_mode,
+            self.proposal_cipher.clone(),
         );
 
         let tx = builder
@@ -208,6 +270,7 @@ impl ExecutionLayer {
                 batch,
                 self.preconfer_address,
                 self.contract_addresses.clone(),
+                num_forced_inclusions,
             )
             .await?;
 

--- a/realtime/src/l1/proposal_tx_builder.rs
+++ b/realtime/src/l1/proposal_tx_builder.rs
@@ -64,7 +64,6 @@ impl ProposalTxBuilder {
     /// `recover_from_failed_submission` (reorg back to last finalized head).
     const BLOB_TX_GAS_LIMIT: u64 = 3_000_000;
 
-    #[allow(clippy::too_many_arguments)]
     pub async fn build_propose_tx(
         &self,
         batch: Proposal,
@@ -92,7 +91,6 @@ impl ProposalTxBuilder {
         Ok(tx_blob)
     }
 
-    #[allow(clippy::too_many_arguments)]
     pub async fn build_propose_blob(
         &self,
         batch: Proposal,

--- a/realtime/src/l1/proposal_tx_builder.rs
+++ b/realtime/src/l1/proposal_tx_builder.rs
@@ -35,6 +35,7 @@ pub struct ProposalTxBuilder {
     extra_gas_percentage: u64,
     proof_type: ProofType,
     mock_mode: bool,
+    cipher: crate::privacy::ProposalCipher,
 }
 
 impl ProposalTxBuilder {
@@ -43,12 +44,14 @@ impl ProposalTxBuilder {
         extra_gas_percentage: u64,
         proof_type: ProofType,
         mock_mode: bool,
+        cipher: crate::privacy::ProposalCipher,
     ) -> Self {
         Self {
             provider,
             extra_gas_percentage,
             proof_type,
             mock_mode,
+            cipher,
         }
     }
 
@@ -67,9 +70,10 @@ impl ProposalTxBuilder {
         batch: Proposal,
         from: Address,
         contract_addresses: ContractAddresses,
+        num_forced_inclusions: u16,
     ) -> Result<TransactionRequest, Error> {
         let tx_blob = self
-            .build_propose_blob(batch, from, contract_addresses)
+            .build_propose_blob(batch, from, contract_addresses, num_forced_inclusions)
             .await?;
 
         let tx_blob_gas =
@@ -94,6 +98,7 @@ impl ProposalTxBuilder {
         batch: Proposal,
         from: Address,
         contract_addresses: ContractAddresses,
+        num_forced_inclusions: u16,
     ) -> Result<TransactionRequest, Error> {
         // Collect required return signals from all l1_calls that expect an L1→L2
         // return signal to be produced by their invoked target. When non-empty, the
@@ -118,6 +123,7 @@ impl ProposalTxBuilder {
                 contract_addresses.realtime_inbox,
                 use_deferred,
                 &required_return_signals,
+                num_forced_inclusions,
             )
             .await?;
 
@@ -222,6 +228,7 @@ impl ProposalTxBuilder {
         inbox_address: Address,
         use_deferred: bool,
         required_return_signals: &[alloy::primitives::FixedBytes<32>],
+        num_forced_inclusions: u16,
     ) -> Result<(Vec<Multicall::Call>, BlobTransactionSidecarEip7594), anyhow::Error> {
         let mut block_manifests = <Vec<BlockManifest>>::with_capacity(batch.l2_blocks.len());
         for l2_block in &batch.l2_blocks {
@@ -247,7 +254,14 @@ impl ProposalTxBuilder {
             .encode_and_compress()
             .map_err(|e| Error::msg(format!("Can't encode and compress manifest: {e}")))?;
 
-        let sidecar_builder: SidecarBuilder<BlobCoder> = SidecarBuilder::from_slice(&manifest_data);
+        // Privacy: prepend the scheme byte and (if enabled) AES-256-GCM-encrypt the
+        // compressed manifest. The driver and prover apply the inverse on the bytes
+        // they fetch from the beacon node. The blob hash on L1 is over these wrapped
+        // bytes; both sites (here and async_submitter) MUST use the same cipher so
+        // the L1 hash and the bytes Raiko sees stay consistent.
+        let blob_payload = self.cipher.wrap(&manifest_data)?;
+
+        let sidecar_builder: SidecarBuilder<BlobCoder> = SidecarBuilder::from_slice(&blob_payload);
         let sidecar: BlobTransactionSidecarEip7594 = sidecar_builder.build_7594()?;
 
         let inbox = RealTimeInbox::new(inbox_address, self.provider.clone());
@@ -287,6 +301,7 @@ impl ProposalTxBuilder {
             // Classic propose flow
             let propose_input = ProposeInput {
                 blobReference: blob_reference,
+                numForcedInclusions: num_forced_inclusions,
                 signalSlots: batch.signal_slots.clone(),
                 maxAnchorBlockNumber: U48::from(batch.max_anchor_block_number),
             };
@@ -318,6 +333,7 @@ impl ProposalTxBuilder {
 
         let propose_input_v2 = ProposeInputV2 {
             blobReference: blob_reference,
+            numForcedInclusions: num_forced_inclusions,
             existingSignals: existing_signals,
             requiredReturnSignals: required_return_signals.to_vec(),
             maxAnchorBlockNumber: U48::from(batch.max_anchor_block_number),

--- a/realtime/src/l1/proposal_tx_builder.rs
+++ b/realtime/src/l1/proposal_tx_builder.rs
@@ -254,12 +254,15 @@ impl ProposalTxBuilder {
             .encode_and_compress()
             .map_err(|e| Error::msg(format!("Can't encode and compress manifest: {e}")))?;
 
-        // Privacy: prepend the scheme byte and (if enabled) AES-256-GCM-encrypt the
-        // compressed manifest. The driver and prover apply the inverse on the bytes
-        // they fetch from the beacon node. The blob hash on L1 is over these wrapped
-        // bytes; both sites (here and async_submitter) MUST use the same cipher so
-        // the L1 hash and the bytes Raiko sees stay consistent.
-        let blob_payload = self.cipher.wrap(&manifest_data)?;
+        // Privacy: re-frame the compressed manifest as [Shasta frame(64B) ||
+        // scheme(1B) || scheme_body]. The privacy scheme byte must sit *inside*
+        // the Shasta frame, otherwise raiko's blob_tx_slice_param_for_source and
+        // the driver's ExtractVersionAndSize will read the scheme as the first
+        // byte of the version field and reject the blob. Both blob-emitting sites
+        // (here and async_submitter) MUST use the same helper so the L1-blob hash
+        // and the bytes Raiko sees stay consistent.
+        let blob_payload =
+            crate::privacy::build_blob_payload(&manifest_data, &self.cipher)?;
 
         let sidecar_builder: SidecarBuilder<BlobCoder> = SidecarBuilder::from_slice(&blob_payload);
         let sidecar: BlobTransactionSidecarEip7594 = sidecar_builder.build_7594()?;

--- a/realtime/src/l1/proposal_tx_builder.rs
+++ b/realtime/src/l1/proposal_tx_builder.rs
@@ -230,39 +230,47 @@ impl ProposalTxBuilder {
         required_return_signals: &[alloy::primitives::FixedBytes<32>],
         num_forced_inclusions: u16,
     ) -> Result<(Vec<Multicall::Call>, BlobTransactionSidecarEip7594), anyhow::Error> {
-        let mut block_manifests = <Vec<BlockManifest>>::with_capacity(batch.l2_blocks.len());
-        for l2_block in &batch.l2_blocks {
-            block_manifests.push(BlockManifest {
-                timestamp: l2_block.timestamp_sec,
-                coinbase: l2_block.coinbase,
-                anchor_block_number: l2_block.anchor_block_number,
-                gas_limit: l2_block.gas_limit_without_anchor,
-                transactions: l2_block
-                    .prebuilt_tx_list
-                    .tx_list
-                    .iter()
-                    .map(|tx| tx.clone().into())
-                    .collect(),
-            });
-        }
-
-        let manifest = DerivationSourceManifest {
-            blocks: block_manifests,
+        // Prefer the blob_payload that async_submitter computed before the Raiko
+        // call. AES-256-GCM uses a random nonce, so re-encrypting here would
+        // produce a different ciphertext (and different blob hash) than the one
+        // Raiko proved against — the proof would no longer match the on-chain
+        // blob hash and `propose` would revert. Falling back to compute-on-the-fly
+        // is only safe in plaintext mode (deterministic output) and we keep it as
+        // a defensive fallback for codepaths that bypass async_submitter.
+        let blob_payload = match batch.blob_payload.as_ref() {
+            Some(payload) => payload.clone(),
+            None => {
+                if self.cipher.is_enabled() {
+                    tracing::warn!(
+                        "Proposal.blob_payload missing in privacy mode — re-encrypting will mint a fresh nonce. \
+                         If a Raiko proof was generated against a different nonce this propose call will revert."
+                    );
+                }
+                let mut block_manifests =
+                    <Vec<BlockManifest>>::with_capacity(batch.l2_blocks.len());
+                for l2_block in &batch.l2_blocks {
+                    block_manifests.push(BlockManifest {
+                        timestamp: l2_block.timestamp_sec,
+                        coinbase: l2_block.coinbase,
+                        anchor_block_number: l2_block.anchor_block_number,
+                        gas_limit: l2_block.gas_limit_without_anchor,
+                        transactions: l2_block
+                            .prebuilt_tx_list
+                            .tx_list
+                            .iter()
+                            .map(|tx| tx.clone().into())
+                            .collect(),
+                    });
+                }
+                let manifest = DerivationSourceManifest {
+                    blocks: block_manifests,
+                };
+                let manifest_data = manifest
+                    .encode_and_compress()
+                    .map_err(|e| Error::msg(format!("Can't encode and compress manifest: {e}")))?;
+                crate::privacy::build_blob_payload(&manifest_data, &self.cipher)?
+            }
         };
-
-        let manifest_data = manifest
-            .encode_and_compress()
-            .map_err(|e| Error::msg(format!("Can't encode and compress manifest: {e}")))?;
-
-        // Privacy: re-frame the compressed manifest as [Shasta frame(64B) ||
-        // scheme(1B) || scheme_body]. The privacy scheme byte must sit *inside*
-        // the Shasta frame, otherwise raiko's blob_tx_slice_param_for_source and
-        // the driver's ExtractVersionAndSize will read the scheme as the first
-        // byte of the version field and reject the blob. Both blob-emitting sites
-        // (here and async_submitter) MUST use the same helper so the L1-blob hash
-        // and the bytes Raiko sees stay consistent.
-        let blob_payload =
-            crate::privacy::build_blob_payload(&manifest_data, &self.cipher)?;
 
         let sidecar_builder: SidecarBuilder<BlobCoder> = SidecarBuilder::from_slice(&blob_payload);
         let sidecar: BlobTransactionSidecarEip7594 = sidecar_builder.build_7594()?;

--- a/realtime/src/lib.rs
+++ b/realtime/src/lib.rs
@@ -2,6 +2,7 @@ mod chain_monitor;
 mod l1;
 mod l2;
 mod node;
+mod privacy;
 pub mod raiko;
 mod shared_abi;
 mod utils;

--- a/realtime/src/node/proposal_manager/async_submitter.rs
+++ b/realtime/src/node/proposal_manager/async_submitter.rs
@@ -181,12 +181,15 @@ async fn submission_task(
         let manifest_data = manifest.encode_and_compress()?;
 
         // Privacy: re-frame [Shasta frame(64B) || scheme(1B) || scheme_body] using
-        // the same cipher and helper as the L1 proposal_tx_builder. Both sites MUST
-        // agree, otherwise the blob hashes Raiko computes here will not match the
-        // hashes recorded on L1 by `propose`, and the proof's commitment will
-        // diverge from on-chain state.
+        // the cipher. AES-256-GCM uses a fresh random nonce per call, so this MUST
+        // run exactly once for a given proposal — otherwise the L1 sidecar (built
+        // from Proposal in proposal_tx_builder) and the Raiko request blobs would
+        // have different nonces, different ciphertexts, and different blob hashes.
+        // We persist the result on `proposal.blob_payload` so the L1 sidecar uses
+        // the same bytes Raiko proved against.
         let cipher = ethereum_l1.execution_layer.proposal_cipher();
         let blob_payload = crate::privacy::build_blob_payload(&manifest_data, &cipher)?;
+        proposal.blob_payload = Some(blob_payload.clone());
 
         let sidecar_builder: SidecarBuilder<BlobCoder> = SidecarBuilder::from_slice(&blob_payload);
         let sidecar: alloy::eips::eip7594::BlobTransactionSidecarEip7594 =

--- a/realtime/src/node/proposal_manager/async_submitter.rs
+++ b/realtime/src/node/proposal_manager/async_submitter.rs
@@ -179,7 +179,17 @@ async fn submission_task(
             blocks: block_manifests,
         };
         let manifest_data = manifest.encode_and_compress()?;
-        let sidecar_builder: SidecarBuilder<BlobCoder> = SidecarBuilder::from_slice(&manifest_data);
+
+        // Privacy: wrap with the same cipher used by the L1 proposal_tx_builder.
+        // Both sites MUST agree, otherwise the blob hashes Raiko computes here
+        // will not match the hashes recorded on L1 by `propose`, and the proof's
+        // commitment will diverge from on-chain state.
+        let blob_payload = ethereum_l1
+            .execution_layer
+            .proposal_cipher()
+            .wrap(&manifest_data)?;
+
+        let sidecar_builder: SidecarBuilder<BlobCoder> = SidecarBuilder::from_slice(&blob_payload);
         let sidecar: alloy::eips::eip7594::BlobTransactionSidecarEip7594 =
             sidecar_builder.build_7594()?;
 

--- a/realtime/src/node/proposal_manager/async_submitter.rs
+++ b/realtime/src/node/proposal_manager/async_submitter.rs
@@ -180,14 +180,13 @@ async fn submission_task(
         };
         let manifest_data = manifest.encode_and_compress()?;
 
-        // Privacy: wrap with the same cipher used by the L1 proposal_tx_builder.
-        // Both sites MUST agree, otherwise the blob hashes Raiko computes here
-        // will not match the hashes recorded on L1 by `propose`, and the proof's
-        // commitment will diverge from on-chain state.
-        let blob_payload = ethereum_l1
-            .execution_layer
-            .proposal_cipher()
-            .wrap(&manifest_data)?;
+        // Privacy: re-frame [Shasta frame(64B) || scheme(1B) || scheme_body] using
+        // the same cipher and helper as the L1 proposal_tx_builder. Both sites MUST
+        // agree, otherwise the blob hashes Raiko computes here will not match the
+        // hashes recorded on L1 by `propose`, and the proof's commitment will
+        // diverge from on-chain state.
+        let cipher = ethereum_l1.execution_layer.proposal_cipher();
+        let blob_payload = crate::privacy::build_blob_payload(&manifest_data, &cipher)?;
 
         let sidecar_builder: SidecarBuilder<BlobCoder> = SidecarBuilder::from_slice(&blob_payload);
         let sidecar: alloy::eips::eip7594::BlobTransactionSidecarEip7594 =

--- a/realtime/src/node/proposal_manager/batch_builder.rs
+++ b/realtime/src/node/proposal_manager/batch_builder.rs
@@ -88,6 +88,7 @@ impl BatchBuilder {
             signal_slots: vec![],
             l1_calls: vec![],
             zk_proof: None,
+            blob_payload: None,
         });
     }
 

--- a/realtime/src/node/proposal_manager/proposal.rs
+++ b/realtime/src/node/proposal_manager/proposal.rs
@@ -37,6 +37,15 @@ pub struct Proposal {
 
     // ZK proof (populated after Raiko call)
     pub zk_proof: Option<Vec<u8>>,
+
+    /// Pre-encrypted blob payload (full Shasta-framed inner buffer that goes to
+    /// `SidecarBuilder::from_slice`). Populated by `async_submitter` before the
+    /// Raiko call so the blob hashes Raiko's proof commits to are byte-identical
+    /// to the blob hashes posted on L1. Without this, AES-256-GCM's random nonce
+    /// would make `proposal_tx_builder`'s second `build_blob_payload` call
+    /// produce a different ciphertext and a different blob hash than the one
+    /// Raiko proved against.
+    pub blob_payload: Option<Vec<u8>>,
 }
 
 impl Proposal {

--- a/realtime/src/privacy/aes.rs
+++ b/realtime/src/privacy/aes.rs
@@ -1,0 +1,91 @@
+//! AES-256-GCM with a freshly random 12-byte nonce per call.
+//!
+//! The nonce is drawn from the OS CSPRNG (`OsRng`). 96-bit random nonces give
+//! collision probability ~2⁻³² after 2³² messages, far beyond Surge's lifetime.
+//! Re-using a (key, nonce) pair under AES-GCM is catastrophic, so we MUST never
+//! derive the nonce deterministically.
+
+use aes_gcm::aead::{Aead, KeyInit, Payload};
+use aes_gcm::{Aes256Gcm, Key, Nonce};
+use rand::rngs::OsRng;
+use rand::RngCore;
+
+/// Length of the AES-GCM nonce in bytes.
+pub const NONCE_LEN: usize = 12;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AesError {
+    Encrypt,
+}
+
+/// Encrypts `plaintext` under `key` and returns the inner blob payload
+/// `[nonce(12B) || ciphertext || tag(16B)]` (without the outer scheme byte).
+pub fn encrypt_random_nonce(plaintext: &[u8], key: &[u8; 32]) -> Result<Vec<u8>, AesError> {
+    let mut nonce = [0u8; NONCE_LEN];
+    OsRng.fill_bytes(&mut nonce);
+    encrypt_with_nonce(plaintext, key, &nonce)
+}
+
+/// Encrypts under an explicit nonce. Exposed for deterministic tests; production code
+/// goes through `encrypt_random_nonce`.
+pub fn encrypt_with_nonce(
+    plaintext: &[u8],
+    key: &[u8; 32],
+    nonce: &[u8; NONCE_LEN],
+) -> Result<Vec<u8>, AesError> {
+    let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(key));
+    let ct = cipher
+        .encrypt(
+            Nonce::from_slice(nonce),
+            Payload {
+                msg: plaintext,
+                aad: &[],
+            },
+        )
+        .map_err(|_| AesError::Encrypt)?;
+    let mut out = Vec::with_capacity(NONCE_LEN + ct.len());
+    out.extend_from_slice(nonce);
+    out.extend_from_slice(&ct);
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aes_gcm::aead::{Aead, KeyInit, Payload};
+    use aes_gcm::{Aes256Gcm, Key, Nonce};
+
+    #[test]
+    fn roundtrip_via_aes_gcm_decrypt() {
+        // Encrypt with our helper, decrypt with a stock AES-GCM call to verify layout.
+        let key = [0x42u8; 32];
+        let nonce = [0x37u8; NONCE_LEN];
+        let m = b"compressed manifest goes here";
+        let inner = encrypt_with_nonce(m, &key, &nonce).unwrap();
+
+        // [nonce(12) || ct(len(m)) || tag(16)]
+        assert_eq!(&inner[..12], &nonce);
+        assert_eq!(inner.len(), 12 + m.len() + 16);
+
+        // Decrypt the ct+tag tail with a fresh AES-GCM instance.
+        let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(&key));
+        let pt = cipher
+            .decrypt(
+                Nonce::from_slice(&nonce),
+                Payload {
+                    msg: &inner[12..],
+                    aad: &[],
+                },
+            )
+            .unwrap();
+        assert_eq!(pt, m);
+    }
+
+    #[test]
+    fn random_nonce_changes_per_call() {
+        let key = [0u8; 32];
+        let a = encrypt_random_nonce(b"x", &key).unwrap();
+        let b = encrypt_random_nonce(b"x", &key).unwrap();
+        assert_ne!(&a[..12], &b[..12]);
+    }
+}

--- a/realtime/src/privacy/aes.rs
+++ b/realtime/src/privacy/aes.rs
@@ -5,10 +5,9 @@
 //! Re-using a (key, nonce) pair under AES-GCM is catastrophic, so we MUST never
 //! derive the nonce deterministically.
 
-use aes_gcm::aead::{Aead, KeyInit, Payload};
+use aes_gcm::aead::rand_core::RngCore;
+use aes_gcm::aead::{Aead, KeyInit, OsRng, Payload};
 use aes_gcm::{Aes256Gcm, Key, Nonce};
-use rand::RngCore;
-use rand::rngs::OsRng;
 
 /// Length of the AES-GCM nonce in bytes.
 pub const NONCE_LEN: usize = 12;

--- a/realtime/src/privacy/aes.rs
+++ b/realtime/src/privacy/aes.rs
@@ -7,8 +7,8 @@
 
 use aes_gcm::aead::{Aead, KeyInit, Payload};
 use aes_gcm::{Aes256Gcm, Key, Nonce};
-use rand::rngs::OsRng;
 use rand::RngCore;
+use rand::rngs::OsRng;
 
 /// Length of the AES-GCM nonce in bytes.
 pub const NONCE_LEN: usize = 12;

--- a/realtime/src/privacy/mod.rs
+++ b/realtime/src/privacy/mod.rs
@@ -31,7 +31,7 @@
 pub mod aes;
 
 use alloy::primitives::U256;
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 
 /// Length of the Shasta `[bytes32(version) || bytes32(size)]` outer frame.
 const SHASTA_FRAME_LEN: usize = 64;

--- a/realtime/src/privacy/mod.rs
+++ b/realtime/src/privacy/mod.rs
@@ -234,4 +234,53 @@ mod tests {
         let too_short = vec![0u8; 63];
         assert!(build_blob_payload(&too_short, &cipher).is_err());
     }
+
+    /// Reproduces raiko's `blob_tx_slice_param_for_source` parser
+    /// (`raiko/lib/src/input.rs:442`) on this helper's output and asserts the
+    /// returned `(start, size)` slice exactly equals the cipher-wrapped inner.
+    /// This test is the regression guard for the bug where the scheme byte was
+    /// emitted *outside* the frame and raiko rejected the payload.
+    #[test]
+    fn build_blob_payload_passes_raiko_slice_parser() {
+        // Synthetic encode_and_compress output (frame contents are stripped, so
+        // we don't bother making them realistic).
+        let compressed = b"compressed-manifest-payload";
+        let mut framed_input = Vec::new();
+        framed_input.extend_from_slice(&[0u8; 64]);
+        framed_input.extend_from_slice(compressed);
+
+        let cipher = ProposalCipher::enabled([0xAAu8; 32]);
+        let out = build_blob_payload(&framed_input, &cipher).unwrap();
+
+        // ─── Mimic raiko's parser, byte for byte ─────────────────────────────
+        let offset = 0usize;
+
+        // version check: bytes32(1) == [0u8; 31] || 0x01
+        let mut expected_version = [0u8; 32];
+        expected_version[31] = 1;
+        assert_eq!(
+            &out[offset..offset + 32],
+            &expected_version,
+            "version frame must be bytes32(1)"
+        );
+
+        // size: read bytes [offset+32 .. offset+64] as B256, take last 8 BE → u64.
+        let size_b256: [u8; 32] = out[offset + 32..offset + 64].try_into().unwrap();
+        let size_bytes: [u8; 8] = size_b256[24..32].try_into().unwrap();
+        let blob_data_size = u64::from_be_bytes(size_bytes) as usize;
+
+        let start = offset + 64;
+        let end = start + blob_data_size;
+        assert!(end <= out.len(), "advertised size must fit");
+
+        let sliced = &out[start..end];
+
+        // The slice must equal cipher.wrap(compressed_manifest) exactly.
+        let expected_inner_len = 1 + 12 + compressed.len() + 16; // scheme + nonce + ct + tag
+        assert_eq!(sliced.len(), expected_inner_len);
+        assert_eq!(sliced[0], SCHEME_AES256_GCM);
+
+        // The dispatcher would now strip the scheme byte and feed the rest to AES.
+        // (We don't redo the round-trip here — `aes::tests::roundtrip` covers that.)
+    }
 }

--- a/realtime/src/privacy/mod.rs
+++ b/realtime/src/privacy/mod.rs
@@ -10,14 +10,77 @@
 //! `RealTimeInbox.saveForcedInclusion`. Catalyst only references their blob hashes via
 //! `numForcedInclusions` on the propose input — it never re-encrypts FI payloads.
 //!
-//! Byte layout (mirrors `raiko/lib/src/privacy/`):
+//! Wire layout (full blob payload buffer fed into `SidecarBuilder::from_slice`):
+//!
+//! ```text
+//! [ bytes32(version=1) (32B) ] [ bytes32(size) (32B) ] [ scheme (1B) ] [ scheme_body ]
+//!                                                       └───── inner ────────┘
+//!                                                       size = 1 + len(scheme_body)
+//! ```
+//!
+//! Inner shape per scheme (mirrors `raiko/lib/src/privacy/`):
 //!
 //! - Plaintext (scheme 0x00): `[0x00 || compressed_manifest]`
 //! - AES-256-GCM (scheme 0x01): `[0x01 || nonce(12B) || ciphertext || tag(16B)]`
+//!
+//! [`build_blob_payload`] is the helper that performs the end-to-end transform from
+//! `manifest.encode_and_compress()` framed bytes to the corrected `[frame || inner]`
+//! buffer; both the L1 proposal-tx builder and the Raiko-request submitter use it so
+//! the bytes hashed on L1 match the bytes Raiko sees.
 
 pub mod aes;
 
+use alloy::primitives::U256;
 use anyhow::{anyhow, Result};
+
+/// Length of the Shasta `[bytes32(version) || bytes32(size)]` outer frame.
+const SHASTA_FRAME_LEN: usize = 64;
+
+/// `SHASTA_PAYLOAD_VERSION` from `taiko_protocol::shasta::constants`. Hard-coded here
+/// to keep the privacy module self-contained; if upstream bumps this value, this constant
+/// must be updated in lockstep (the unit tests will catch a mismatch on round-trip).
+const SHASTA_PAYLOAD_VERSION: u8 = 0x01;
+
+/// Re-frames the output of `taiko_protocol::shasta::manifest::DerivationSourceManifest::
+/// encode_and_compress` so the privacy scheme byte sits *inside* the Shasta frame, not
+/// before it.
+///
+/// `framed_input` is `encode_and_compress`'s return value: `[frame(64) || compressed_manifest]`.
+/// The frame is stripped, the compressed manifest is wrapped via `cipher` (producing
+/// `[scheme || scheme_body]`), and a fresh frame with the new size is prepended. The
+/// returned buffer is what `SidecarBuilder::from_slice` should consume.
+///
+/// Without this re-framing, `cipher.wrap(framed_input)` would emit
+/// `[scheme || frame || compressed_manifest]`, which causes raiko's
+/// `blob_tx_slice_param_for_source` to read the scheme byte as the first byte of the
+/// version field and reject the blob.
+pub fn build_blob_payload(framed_input: &[u8], cipher: &ProposalCipher) -> Result<Vec<u8>> {
+    if framed_input.len() < SHASTA_FRAME_LEN {
+        return Err(anyhow!(
+            "encode_and_compress output shorter than Shasta frame: {} < {}",
+            framed_input.len(),
+            SHASTA_FRAME_LEN
+        ));
+    }
+    let compressed_manifest = &framed_input[SHASTA_FRAME_LEN..];
+
+    // [scheme(1B) || scheme_body]
+    let inner = cipher.wrap(compressed_manifest)?;
+
+    let mut out = Vec::with_capacity(SHASTA_FRAME_LEN + inner.len());
+
+    // bytes32(version) = [0u8; 31] || SHASTA_PAYLOAD_VERSION
+    let mut version = [0u8; 32];
+    version[31] = SHASTA_PAYLOAD_VERSION;
+    out.extend_from_slice(&version);
+
+    // bytes32(size) = U256(inner.len()).to_be_bytes::<32>()
+    let size_bytes: [u8; 32] = U256::from(inner.len()).to_be_bytes();
+    out.extend_from_slice(&size_bytes);
+
+    out.extend_from_slice(&inner);
+    Ok(out)
+}
 
 /// Plaintext (no encryption).
 pub const SCHEME_PLAIN: u8 = 0x00;
@@ -108,5 +171,67 @@ mod tests {
         assert_eq!(a.len(), b.len());
         assert_ne!(a, b);
         assert_ne!(&a[1..13], &b[1..13]); // nonces differ
+    }
+
+    /// Builds a synthetic `encode_and_compress` output (`[frame(64) || compressed]`)
+    /// and verifies `build_blob_payload` re-emits the frame around the cipher-wrapped
+    /// inner — version byte at index 31, size matching `inner.len()`, scheme byte at
+    /// index 64. This is the layout raiko's `blob_tx_slice_param_for_source` and the
+    /// driver's `ExtractVersionAndSize` both expect.
+    #[test]
+    fn build_blob_payload_reframes_around_inner() {
+        // Synthesize what encode_and_compress would have returned.
+        let compressed = b"compressed-manifest-bytes";
+        let mut framed_input = Vec::with_capacity(64 + compressed.len());
+        let mut version = [0u8; 32];
+        version[31] = SHASTA_PAYLOAD_VERSION;
+        framed_input.extend_from_slice(&version);
+        let size_bytes: [u8; 32] = U256::from(compressed.len()).to_be_bytes();
+        framed_input.extend_from_slice(&size_bytes);
+        framed_input.extend_from_slice(compressed);
+
+        // Privacy disabled: inner = [0x00 || compressed].
+        let cipher = ProposalCipher::disabled();
+        let out = build_blob_payload(&framed_input, &cipher).unwrap();
+
+        // Frame: version[31] = 0x01.
+        assert_eq!(out[..31], [0u8; 31]);
+        assert_eq!(out[31], SHASTA_PAYLOAD_VERSION);
+
+        // Frame: size = U256(inner.len()) = U256(1 + compressed.len()).
+        let expected_size: [u8; 32] = U256::from(1 + compressed.len()).to_be_bytes();
+        assert_eq!(&out[32..64], &expected_size);
+
+        // Inner: scheme byte at 64, then the compressed manifest.
+        assert_eq!(out[64], SCHEME_PLAIN);
+        assert_eq!(&out[65..], compressed);
+    }
+
+    #[test]
+    fn build_blob_payload_encrypted_path() {
+        let compressed = b"some-compressed-bytes";
+        let mut framed_input = Vec::with_capacity(64 + compressed.len());
+        framed_input.extend_from_slice(&[0u8; 32]); // version (with last byte unset is fine; we strip)
+        framed_input.extend_from_slice(&[0u8; 32]); // size (we strip)
+        framed_input.extend_from_slice(compressed);
+
+        let cipher = ProposalCipher::enabled([0x42u8; 32]);
+        let out = build_blob_payload(&framed_input, &cipher).unwrap();
+
+        // Re-emitted frame.
+        assert_eq!(out[31], SHASTA_PAYLOAD_VERSION);
+        // Inner length = 1 (scheme) + 12 (nonce) + len(compressed) (ct) + 16 (tag).
+        let expected_inner_len = 1 + 12 + compressed.len() + 16;
+        let expected_size: [u8; 32] = U256::from(expected_inner_len).to_be_bytes();
+        assert_eq!(&out[32..64], &expected_size);
+        assert_eq!(out[64], SCHEME_AES256_GCM);
+        assert_eq!(out.len(), 64 + expected_inner_len);
+    }
+
+    #[test]
+    fn build_blob_payload_rejects_short_input() {
+        let cipher = ProposalCipher::disabled();
+        let too_short = vec![0u8; 63];
+        assert!(build_blob_payload(&too_short, &cipher).is_err());
     }
 }

--- a/realtime/src/privacy/mod.rs
+++ b/realtime/src/privacy/mod.rs
@@ -1,0 +1,112 @@
+//! Blob privacy: encrypts compressed manifests before they become EIP-4844 blobs.
+//!
+//! Catalyst is the *encrypting* side: it generates AES-256-GCM ciphertexts under a
+//! shared symmetric key and emits the inner blob payload `[scheme || ...]` that gets
+//! packed by `SidecarBuilder`. The same scheme bytes and layouts are decoded by the
+//! driver and the raiko prover.
+//!
+//! This crate intentionally does NOT include an ECIES implementation: forced-inclusion
+//! blobs are encrypted by their submitters off-system and posted directly to L1 via
+//! `RealTimeInbox.saveForcedInclusion`. Catalyst only references their blob hashes via
+//! `numForcedInclusions` on the propose input — it never re-encrypts FI payloads.
+//!
+//! Byte layout (mirrors `raiko/lib/src/privacy/`):
+//!
+//! - Plaintext (scheme 0x00): `[0x00 || compressed_manifest]`
+//! - AES-256-GCM (scheme 0x01): `[0x01 || nonce(12B) || ciphertext || tag(16B)]`
+
+pub mod aes;
+
+use anyhow::{anyhow, Result};
+
+/// Plaintext (no encryption).
+pub const SCHEME_PLAIN: u8 = 0x00;
+/// AES-256-GCM with a shared symmetric key.
+pub const SCHEME_AES256_GCM: u8 = 0x01;
+
+/// Encrypts (or pass-through-wraps) the compressed manifest into the inner blob payload
+/// that `SidecarBuilder::from_slice` will pack into the EIP-4844 sidecar.
+///
+/// In privacy mode (`cipher.is_some()`), produces a scheme-0x01 payload with a fresh
+/// random AES-GCM nonce. Otherwise, produces a scheme-0x00 payload (plaintext).
+#[derive(Clone)]
+pub struct ProposalCipher {
+    symmetric_key: Option<[u8; 32]>,
+}
+
+impl ProposalCipher {
+    /// Construct a privacy-disabled cipher (emits scheme 0x00 / plaintext).
+    pub fn disabled() -> Self {
+        Self {
+            symmetric_key: None,
+        }
+    }
+
+    /// Construct a privacy-enabled cipher with the given 32-byte AES-256-GCM key.
+    pub fn enabled(symmetric_key: [u8; 32]) -> Self {
+        Self {
+            symmetric_key: Some(symmetric_key),
+        }
+    }
+
+    /// True if this cipher will produce scheme 0x01 (encrypted) blobs.
+    pub fn is_enabled(&self) -> bool {
+        self.symmetric_key.is_some()
+    }
+
+    /// Wraps `compressed_manifest` (`M`) into the scheme-prefixed inner blob payload.
+    pub fn wrap(&self, compressed_manifest: &[u8]) -> Result<Vec<u8>> {
+        match self.symmetric_key {
+            None => {
+                let mut out = Vec::with_capacity(1 + compressed_manifest.len());
+                out.push(SCHEME_PLAIN);
+                out.extend_from_slice(compressed_manifest);
+                Ok(out)
+            }
+            Some(key) => {
+                let inner = aes::encrypt_random_nonce(compressed_manifest, &key)
+                    .map_err(|e| anyhow!("AES-GCM encrypt failed: {:?}", e))?;
+                let mut out = Vec::with_capacity(1 + inner.len());
+                out.push(SCHEME_AES256_GCM);
+                out.extend_from_slice(&inner);
+                Ok(out)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wrap_plaintext_prepends_scheme_byte() {
+        let cipher = ProposalCipher::disabled();
+        let m = b"the quick brown fox";
+        let out = cipher.wrap(m).unwrap();
+        assert_eq!(out[0], SCHEME_PLAIN);
+        assert_eq!(&out[1..], m);
+    }
+
+    #[test]
+    fn wrap_encrypted_layout() {
+        let cipher = ProposalCipher::enabled([0x42u8; 32]);
+        let m = b"the quick brown fox";
+        let out = cipher.wrap(m).unwrap();
+        // [scheme(1) || nonce(12) || ct(=len(m)) || tag(16)]
+        assert_eq!(out[0], SCHEME_AES256_GCM);
+        assert_eq!(out.len(), 1 + 12 + m.len() + 16);
+    }
+
+    #[test]
+    fn wrap_encrypted_uses_fresh_nonce_each_call() {
+        let cipher = ProposalCipher::enabled([0x42u8; 32]);
+        let m = b"abc";
+        let a = cipher.wrap(m).unwrap();
+        let b = cipher.wrap(m).unwrap();
+        // Same scheme + length, but the nonce (and therefore ciphertext + tag) must differ.
+        assert_eq!(a.len(), b.len());
+        assert_ne!(a, b);
+        assert_ne!(&a[1..13], &b[1..13]); // nonces differ
+    }
+}

--- a/realtime/src/utils/config.rs
+++ b/realtime/src/utils/config.rs
@@ -25,6 +25,16 @@ pub struct RealtimeConfig {
     /// regardless of `proof_type`. Allows using a real Raiko proof type string
     /// while routing on-chain to the DummyProofVerifier.
     pub mock_mode: bool,
+    /// When true, the proposer encrypts every blob payload with AES-256-GCM under
+    /// `privacy_symmetric_key` before posting to L1 (scheme 0x01). When false, blobs
+    /// are emitted with the explicit plaintext scheme byte (0x00). Driver and raiko
+    /// must be configured the same way.
+    pub privacy_mode: bool,
+    /// 32-byte AES-256-GCM key used by Catalyst when `privacy_mode == true`. Required
+    /// in privacy mode; ignored otherwise.
+    pub privacy_symmetric_key: Option<[u8; 32]>,
+    /// Maximum number of forced inclusions to consume per proposal.
+    pub fi_max_per_proposal: u16,
 }
 
 impl ConfigTrait for RealtimeConfig {
@@ -83,6 +93,40 @@ impl ConfigTrait for RealtimeConfig {
             .map(|v| v.to_lowercase() != "false" && v != "0")
             .unwrap_or(false);
 
+        let privacy_mode = std::env::var("SURGE_PRIVACY_MODE")
+            .map(|v| v.to_lowercase() != "false" && v != "0")
+            .unwrap_or(false);
+
+        let privacy_symmetric_key = match std::env::var("SURGE_PRIVACY_SYMMETRIC_KEY") {
+            Ok(hex_str) => {
+                let s = hex_str.strip_prefix("0x").unwrap_or(&hex_str);
+                let bytes = hex::decode(s).map_err(|e| {
+                    anyhow::anyhow!("SURGE_PRIVACY_SYMMETRIC_KEY: invalid hex: {e}")
+                })?;
+                if bytes.len() != 32 {
+                    return Err(anyhow::anyhow!(
+                        "SURGE_PRIVACY_SYMMETRIC_KEY: expected 32 bytes, got {}",
+                        bytes.len()
+                    ));
+                }
+                let mut arr = [0u8; 32];
+                arr.copy_from_slice(&bytes);
+                Some(arr)
+            }
+            Err(_) => None,
+        };
+
+        if privacy_mode && privacy_symmetric_key.is_none() {
+            return Err(anyhow::anyhow!(
+                "SURGE_PRIVACY_MODE=true requires SURGE_PRIVACY_SYMMETRIC_KEY to be set"
+            ));
+        }
+
+        let fi_max_per_proposal: u16 = std::env::var("FI_MAX_PER_PROPOSAL")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(4);
+
         Ok(RealtimeConfig {
             realtime_inbox,
             proposer_multicall,
@@ -99,6 +143,9 @@ impl ConfigTrait for RealtimeConfig {
             preconf_only,
             proof_request_bypass,
             mock_mode,
+            privacy_mode,
+            privacy_symmetric_key,
+            fi_max_per_proposal,
         })
     }
 }
@@ -124,6 +171,8 @@ impl fmt::Display for RealtimeConfig {
         writeln!(f, "User op status DB path: {}", self.user_op_status_db_path)?;
         writeln!(f, "Preconf only: {}", self.preconf_only)?;
         writeln!(f, "Proof request bypass: {}", self.proof_request_bypass)?;
+        writeln!(f, "Privacy mode: {}", self.privacy_mode)?;
+        writeln!(f, "FI max per proposal: {}", self.fi_max_per_proposal)?;
         Ok(())
     }
 }

--- a/realtime/src/utils/config.rs
+++ b/realtime/src/utils/config.rs
@@ -2,9 +2,10 @@ use crate::l1::bindings::ProofType;
 use alloy::primitives::Address;
 use anyhow::Error;
 use common::config::{ConfigTrait, address_parse_error};
+use std::fmt;
 use std::str::FromStr;
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct RealtimeConfig {
     pub realtime_inbox: Address,
     pub proposer_multicall: Address,
@@ -150,7 +151,40 @@ impl ConfigTrait for RealtimeConfig {
     }
 }
 
-use std::fmt;
+/// Manual `Debug` impl that redacts `privacy_symmetric_key`. The derived impl
+/// would print the raw 32-byte key if a `RealtimeConfig` was ever logged via
+/// `{:?}`; for a long-running process that's a leak waiting to happen.
+impl fmt::Debug for RealtimeConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RealtimeConfig")
+            .field("realtime_inbox", &self.realtime_inbox)
+            .field("proposer_multicall", &self.proposer_multicall)
+            .field("bridge", &self.bridge)
+            .field("l2_signal_service", &self.l2_signal_service)
+            .field("raiko_url", &self.raiko_url)
+            .field(
+                "raiko_api_key",
+                &self.raiko_api_key.as_ref().map(|_| "<set>"),
+            )
+            .field("proof_type", &self.proof_type)
+            .field("raiko_poll_interval_ms", &self.raiko_poll_interval_ms)
+            .field("raiko_max_retries", &self.raiko_max_retries)
+            .field("raiko_timeout_sec", &self.raiko_timeout_sec)
+            .field("bridge_rpc_addr", &self.bridge_rpc_addr)
+            .field("user_op_status_db_path", &self.user_op_status_db_path)
+            .field("preconf_only", &self.preconf_only)
+            .field("proof_request_bypass", &self.proof_request_bypass)
+            .field("mock_mode", &self.mock_mode)
+            .field("privacy_mode", &self.privacy_mode)
+            .field(
+                "privacy_symmetric_key",
+                &self.privacy_symmetric_key.as_ref().map(|_| "<redacted>"),
+            )
+            .field("fi_max_per_proposal", &self.fi_max_per_proposal)
+            .finish()
+    }
+}
+
 impl fmt::Display for RealtimeConfig {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f, "RealTime inbox: {:#?}", self.realtime_inbox)?;
@@ -172,6 +206,15 @@ impl fmt::Display for RealtimeConfig {
         writeln!(f, "Preconf only: {}", self.preconf_only)?;
         writeln!(f, "Proof request bypass: {}", self.proof_request_bypass)?;
         writeln!(f, "Privacy mode: {}", self.privacy_mode)?;
+        writeln!(
+            f,
+            "Privacy symmetric key: {}",
+            if self.privacy_symmetric_key.is_some() {
+                "<set>"
+            } else {
+                "<unset>"
+            }
+        )?;
         writeln!(f, "FI max per proposal: {}", self.fi_max_per_proposal)?;
         Ok(())
     }


### PR DESCRIPTION
## Summary

Wires the realtime proposer for the cross-stack privacy feature and re-enables forced-inclusion consumption against the new `RealTimeInbox` queue.

- **Encryption** — new `realtime/src/privacy/` with `ProposalCipher` (AES-256-GCM with a fresh `OsRng` nonce per blob). Applied at both manifest-building sites — the L1 proposal builder and the async Raiko-request builder — so the bytes Raiko sees match what's hashed on L1.
- **Forced inclusion consumption** — `ExecutionLayer.send_batch_to_l1` reads `getForcedInclusionState()` each propose tick, computes `numForcedInclusions = min(pending, fi_max_per_proposal)`, and threads it into `ProposeInput` / `ProposeInputV2`. The contract reverts with `UnprocessedForcedInclusionIsDue` if the cap is below the due count.
- **Config** — `SURGE_PRIVACY_MODE`, `SURGE_PRIVACY_SYMMETRIC_KEY`, `FI_MAX_PER_PROPOSAL` new env vars on `RealtimeConfig`. Privacy mode without a key fails fast at startup. ABI regenerated to expose the new contract methods.
- **No ECIES in Catalyst** — Catalyst never decrypts FI blobs; submitters encrypt them off-system to `PK_sys`.

Companion PRs:
- [surge-taiko-mono#300](https://github.com/NethermindEth/surge-taiko-mono/pull/300) — protocol contracts + driver decryption
- raiko — prover decryption (cipher module + host CLI + guest hash-binding)

See [`PRIVACY_STACK.md`](https://github.com/NethermindEth/surge-taiko-mono/blob/feat/realtime-privacy/PRIVACY_STACK.md) for the cross-stack design reference.
