### PR TITLE
fix(realtime): align RealTimeInbox Config ABI with deployed contract

### DIFF
--- a/realtime/src/l1/abi/RealTimeInbox.json
+++ b/realtime/src/l1/abi/RealTimeInbox.json
@@ -21,21 +21,6 @@
             "name": "basefeeSharingPctg",
             "type": "uint8",
             "internalType": "uint8"
-          },
-          {
-            "name": "forcedInclusionDelay",
-            "type": "uint16",
-            "internalType": "uint16"
-          },
-          {
-            "name": "forcedInclusionFeeInGwei",
-            "type": "uint64",
-            "internalType": "uint64"
-          },
-          {
-            "name": "forcedInclusionFeeDoubleThreshold",
-            "type": "uint64",
-            "internalType": "uint64"
           }
         ]
       }
@@ -215,21 +200,6 @@
             "name": "basefeeSharingPctg",
             "type": "uint8",
             "internalType": "uint8"
-          },
-          {
-            "name": "forcedInclusionDelay",
-            "type": "uint16",
-            "internalType": "uint16"
-          },
-          {
-            "name": "forcedInclusionFeeInGwei",
-            "type": "uint64",
-            "internalType": "uint64"
-          },
-          {
-            "name": "forcedInclusionFeeDoubleThreshold",
-            "type": "uint64",
-            "internalType": "uint64"
           }
         ]
       }


### PR DESCRIPTION
## Problem

Running the node on the realtime fork fails at startup:

```
Failed to create EthereumL1: Failed to call getConfig for RealTimeInbox:
ABI decoding failed: buffer overrun while deserializing
```

The checked-in `RealTimeInbox` ABI declared the `Config` tuple with six fields, but the deployed contract's `Config` struct has only three: `proofVerifier`, `signalService`, `basefeeSharingPctg`. `getConfig()` returns 96 bytes while the decoder (generated from the stale ABI) expected 192, so it ran off the end of the response buffer.

## Fix

Remove the three nonexistent fields (`forcedInclusionDelay`, `forcedInclusionFeeInGwei`, `forcedInclusionFeeDoubleThreshold`) from both the constructor and `getConfig` entries in `realtime/src/l1/abi/RealTimeInbox.json`, matching the on-chain layout. The Rust side only reads `basefeeSharingPctg`, so no code changes are needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)