### PR TITLE
remove outdated checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2338,7 +2338,7 @@ dependencies = [
 
 [[package]]
 name = "common"
-version = "1.39.2"
+version = "1.39.3"
 dependencies = [
  "alloy",
  "alloy-json-rpc",
@@ -5786,7 +5786,7 @@ dependencies = [
 
 [[package]]
 name = "node"
-version = "1.39.2"
+version = "1.39.3"
 dependencies = [
  "anyhow",
  "axum",
@@ -6201,7 +6201,7 @@ dependencies = [
 
 [[package]]
 name = "p2p-boot-node"
-version = "1.39.2"
+version = "1.39.3"
 dependencies = [
  "anyhow",
  "discv5",
@@ -6213,7 +6213,7 @@ dependencies = [
 
 [[package]]
 name = "pacaya"
-version = "1.39.2"
+version = "1.39.3"
 dependencies = [
  "alloy",
  "anyhow",
@@ -6346,7 +6346,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "permissionless"
-version = "1.39.2"
+version = "1.39.3"
 dependencies = [
  "alethia-reth-consensus 0.7.1",
  "alloy",
@@ -7097,7 +7097,7 @@ dependencies = [
 
 [[package]]
 name = "realtime"
-version = "1.39.2"
+version = "1.39.3"
 dependencies = [
  "aes-gcm",
  "alethia-reth-consensus 0.7.1",
@@ -10239,7 +10239,7 @@ dependencies = [
 
 [[package]]
 name = "shasta"
-version = "1.39.2"
+version = "1.39.3"
 dependencies = [
  "alethia-reth-consensus 0.7.1",
  "alloy",
@@ -11475,7 +11475,7 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "urc"
-version = "1.39.2"
+version = "1.39.3"
 dependencies = [
  "alloy",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ resolver = "2"
 default-members = ["node"]
 
 [workspace.package]
-version = "1.39.2"
+version = "1.39.3"
 edition = "2024"
 repository = "https://github.com/NethermindEth/Catalyst"
 license = "MIT"

--- a/pacaya/src/l1/traits.rs
+++ b/pacaya/src/l1/traits.rs
@@ -10,9 +10,6 @@ pub trait PreconfOperator {
         current_epoch_timestamp: u64,
         current_slot_timestamp: u64,
     ) -> impl Future<Output = Result<(Address, Address), OperatorError>> + Send;
-    fn is_preconf_router_specified_in_taiko_wrapper(
-        &self,
-    ) -> impl Future<Output = Result<bool, Error>> + Send;
     fn get_l2_height_from_taiko_inbox(&self) -> impl Future<Output = Result<u64, Error>> + Send;
     fn get_handover_window_slots(&self) -> impl Future<Output = Result<u64, Error>> + Send;
 }

--- a/pacaya/src/l1/traits.rs
+++ b/pacaya/src/l1/traits.rs
@@ -11,7 +11,6 @@ pub trait PreconfOperator {
         current_slot_timestamp: u64,
     ) -> impl Future<Output = Result<(Address, Address), OperatorError>> + Send;
     fn get_l2_height_from_taiko_inbox(&self) -> impl Future<Output = Result<u64, Error>> + Send;
-    fn get_handover_window_slots(&self) -> impl Future<Output = Result<u64, Error>> + Send;
 }
 
 pub trait WhitelistProvider: Send + Sync {

--- a/pacaya/src/node/operator/mod.rs
+++ b/pacaya/src/node/operator/mod.rs
@@ -19,7 +19,6 @@ pub struct Operator<T: PreconfOperator, U: Clock, V: StatusProvider> {
     execution_layer: Arc<T>,
     slot_clock: Arc<SlotClock<U>>,
     taiko: Arc<V>,
-    handover_window_slots_default: u64,
     handover_window_slots: u64,
     handover_start_buffer_ms: u64,
     next_operator: bool,
@@ -28,7 +27,6 @@ pub struct Operator<T: PreconfOperator, U: Clock, V: StatusProvider> {
     was_synced_preconfer: bool,
     cancel_token: CancellationToken,
     cancel_counter: u64,
-    last_config_reload_epoch: u64,
     fork_info: ForkInfo,
     current_operator_address: Address,
     last_ejection_timestamp: Option<u64>,
@@ -52,7 +50,6 @@ impl<T: PreconfOperator, U: Clock, V: StatusProvider> Operator<T, U, V> {
             execution_layer,
             slot_clock,
             taiko,
-            handover_window_slots_default: handover_window_slots,
             handover_window_slots,
             handover_start_buffer_ms,
             next_operator: false,
@@ -61,7 +58,6 @@ impl<T: PreconfOperator, U: Clock, V: StatusProvider> Operator<T, U, V> {
             was_synced_preconfer: false,
             cancel_token,
             cancel_counter: 0,
-            last_config_reload_epoch: 0,
             fork_info,
             current_operator_address: Address::ZERO,
             last_ejection_timestamp: None,
@@ -76,18 +72,7 @@ impl<T: PreconfOperator, U: Clock, V: StatusProvider> Operator<T, U, V> {
         let start = std::time::Instant::now();
 
         let l1_slot: u64 = self.slot_clock.get_current_slot_of_epoch()?;
-
         let epoch = self.slot_clock.get_current_epoch()?;
-        if epoch > self.last_config_reload_epoch {
-            self.handover_window_slots = self.get_handover_window_slots().await;
-            debug!(
-                "Reloaded router config. Handover window slots: {}",
-                self.handover_window_slots
-            );
-            self.last_config_reload_epoch = epoch;
-        }
-        #[cfg(feature = "get_status_duration")]
-        let check_handover_window_slots = start.elapsed();
 
         let current_operator = self.is_current_operator(epoch).await?;
         #[cfg(feature = "get_status_duration")]
@@ -132,7 +117,6 @@ impl<T: PreconfOperator, U: Clock, V: StatusProvider> Operator<T, U, V> {
 
         #[cfg(feature = "get_status_duration")]
         let durations = status::StatusCheckDurations {
-            check_handover_window_slots,
             check_current_operator,
             check_handover_window,
             check_driver_status,
@@ -417,18 +401,5 @@ impl<T: PreconfOperator, U: Clock, V: StatusProvider> Operator<T, U, V> {
             .await?;
 
         Ok(l2_slot_info.parent_id() >= taiko_inbox_height)
-    }
-
-    async fn get_handover_window_slots(&self) -> u64 {
-        match self.execution_layer.get_handover_window_slots().await {
-            Ok(router_config) => router_config,
-            Err(e) => {
-                warn!(
-                    "Failed to get preconf router config, using default handover window slots: {}",
-                    e
-                );
-                self.handover_window_slots_default
-            }
-        }
     }
 }

--- a/pacaya/src/node/operator/mod.rs
+++ b/pacaya/src/node/operator/mod.rs
@@ -74,25 +74,6 @@ impl<T: PreconfOperator, U: Clock, V: StatusProvider> Operator<T, U, V> {
         // feature get_status_duration
         #[cfg(feature = "get_status_duration")]
         let start = std::time::Instant::now();
-        if !self
-            .execution_layer
-            .is_preconf_router_specified_in_taiko_wrapper()
-            .await?
-        {
-            warn!("PreconfRouter is not specified in TaikoWrapper");
-            self.reset();
-            return Ok(Status::new(
-                false,
-                false,
-                false,
-                false,
-                false,
-                #[cfg(feature = "get_status_duration")]
-                None,
-            ));
-        }
-        #[cfg(feature = "get_status_duration")]
-        let check_taiko_wrapper = start.elapsed();
 
         let l1_slot: u64 = self.slot_clock.get_current_slot_of_epoch()?;
 
@@ -151,7 +132,6 @@ impl<T: PreconfOperator, U: Clock, V: StatusProvider> Operator<T, U, V> {
 
         #[cfg(feature = "get_status_duration")]
         let durations = status::StatusCheckDurations {
-            check_taiko_wrapper,
             check_handover_window_slots,
             check_current_operator,
             check_handover_window,

--- a/pacaya/src/node/operator/status.rs
+++ b/pacaya/src/node/operator/status.rs
@@ -1,7 +1,6 @@
 #[cfg(feature = "get_status_duration")]
 #[cfg_attr(test, derive(Debug))]
 pub struct StatusCheckDurations {
-    pub check_taiko_wrapper: std::time::Duration,
     pub check_handover_window_slots: std::time::Duration,
     pub check_current_operator: std::time::Duration,
     pub check_handover_window: std::time::Duration,

--- a/pacaya/src/node/operator/status.rs
+++ b/pacaya/src/node/operator/status.rs
@@ -1,7 +1,6 @@
 #[cfg(feature = "get_status_duration")]
 #[cfg_attr(test, derive(Debug))]
 pub struct StatusCheckDurations {
-    pub check_handover_window_slots: std::time::Duration,
     pub check_current_operator: std::time::Duration,
     pub check_handover_window: std::time::Duration,
     pub check_driver_status: std::time::Duration,

--- a/pacaya/src/node/operator/tests.rs
+++ b/pacaya/src/node/operator/tests.rs
@@ -29,7 +29,6 @@ mod tests {
         current_operator_address: Address,
         next_operator_address: Address,
         taiko_inbox_height: u64,
-        handover_window_slots: u64,
     }
 
     impl PreconfOperator for ExecutionLayerMock {
@@ -47,35 +46,6 @@ mod tests {
 
         async fn get_l2_height_from_taiko_inbox(&self) -> Result<u64, Error> {
             Ok(self.taiko_inbox_height)
-        }
-
-        async fn get_handover_window_slots(&self) -> Result<u64, Error> {
-            Ok(self.handover_window_slots)
-        }
-    }
-
-    struct ExecutionLayerMockError {}
-    impl PreconfOperator for ExecutionLayerMockError {
-        fn get_preconfer_address(&self) -> Address {
-            PRECONFER_ADDRESS
-        }
-
-        async fn get_operators_for_current_and_next_epoch(
-            &self,
-            _: u64,
-            _: u64,
-        ) -> Result<(Address, Address), OperatorError> {
-            Err(OperatorError::Any(Error::from(anyhow::anyhow!(
-                "test error"
-            ))))
-        }
-
-        async fn get_l2_height_from_taiko_inbox(&self) -> Result<u64, Error> {
-            Err(Error::from(anyhow::anyhow!("test error")))
-        }
-
-        async fn get_handover_window_slots(&self) -> Result<u64, Error> {
-            Err(Error::from(anyhow::anyhow!("test error")))
         }
     }
 
@@ -559,41 +529,6 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn test_long_handover_window_from_config() {
-        let mut operator = create_operator_with_long_handover_window_from_config();
-        assert_eq!(operator.handover_window_slots, HANDOVER_WINDOW_SLOTS);
-        assert_eq!(
-            operator.get_status(&get_l2_slot_info()).await.unwrap(),
-            Status::new(
-                false,
-                true,
-                false,
-                false,
-                true,
-                #[cfg(feature = "get_status_duration")]
-                None,
-            )
-        );
-
-        // during get_status, new handover window slots should be loaded from config
-        assert_eq!(operator.handover_window_slots, 10);
-
-        // another get_status call should not change the handover window slots
-        operator.get_status(&get_l2_slot_info()).await.unwrap();
-        assert_eq!(operator.handover_window_slots, 10);
-    }
-
-    #[tokio::test]
-    async fn test_get_status_with_error_in_execution_layer() {
-        let operator =
-            create_operator_with_error_in_execution_layer(Arc::new(ExecutionLayerMockError {}));
-        assert_eq!(
-            operator.get_handover_window_slots().await,
-            HANDOVER_WINDOW_SLOTS
-        );
-    }
-
     struct ExecutionLayerMockErrorToEarly {}
     impl PreconfOperator for ExecutionLayerMockErrorToEarly {
         fn get_preconfer_address(&self) -> Address {
@@ -610,10 +545,6 @@ mod tests {
 
         async fn get_l2_height_from_taiko_inbox(&self) -> Result<u64, Error> {
             Ok(0)
-        }
-
-        async fn get_handover_window_slots(&self) -> Result<u64, Error> {
-            Ok(HANDOVER_WINDOW_SLOTS)
         }
     }
 
@@ -833,7 +764,6 @@ mod tests {
         Operator {
             fork_info: ForkInfo::default(),
             cancel_token: CancellationToken::new(Arc::new(Metrics::new())),
-            last_config_reload_epoch: 0,
             cancel_counter: 0,
             taiko: Arc::new(TaikoMock {
                 end_of_sequencing_block_hash: B256::ZERO,
@@ -842,11 +772,9 @@ mod tests {
                 current_operator_address,
                 next_operator_address,
                 taiko_inbox_height: 0,
-                handover_window_slots: HANDOVER_WINDOW_SLOTS,
             }),
             slot_clock: Arc::new(slot_clock),
             handover_window_slots: HANDOVER_WINDOW_SLOTS,
-            handover_window_slots_default: HANDOVER_WINDOW_SLOTS,
             handover_start_buffer_ms: 1000,
             next_operator: false,
             continuing_role: false,
@@ -884,7 +812,6 @@ mod tests {
         Operator {
             fork_info: ForkInfo::default(),
             cancel_token: CancellationToken::new(Arc::new(Metrics::new())),
-            last_config_reload_epoch: 0,
             taiko: Arc::new(TaikoMock {
                 end_of_sequencing_block_hash: get_test_hash(),
             }),
@@ -892,11 +819,9 @@ mod tests {
                 current_operator_address,
                 next_operator_address,
                 taiko_inbox_height: 0,
-                handover_window_slots: HANDOVER_WINDOW_SLOTS,
             }),
             slot_clock: Arc::new(slot_clock),
             handover_window_slots: HANDOVER_WINDOW_SLOTS,
-            handover_window_slots_default: HANDOVER_WINDOW_SLOTS,
             handover_start_buffer_ms: 1000,
             next_operator: false,
             continuing_role: false,
@@ -921,7 +846,6 @@ mod tests {
         Operator {
             fork_info: ForkInfo::default(),
             cancel_token: CancellationToken::new(Arc::new(Metrics::new())),
-            last_config_reload_epoch: 0,
             taiko: Arc::new(TaikoUnsyncedMock {
                 end_of_sequencing_block_hash: get_test_hash(),
             }),
@@ -929,11 +853,9 @@ mod tests {
                 current_operator_address,
                 next_operator_address,
                 taiko_inbox_height: 0,
-                handover_window_slots: HANDOVER_WINDOW_SLOTS,
             }),
             slot_clock: Arc::new(slot_clock),
             handover_window_slots: HANDOVER_WINDOW_SLOTS,
-            handover_window_slots_default: HANDOVER_WINDOW_SLOTS,
             handover_start_buffer_ms: 1000,
             next_operator: false,
             continuing_role: false,
@@ -952,7 +874,6 @@ mod tests {
         Operator {
             fork_info: ForkInfo::default(),
             cancel_token: CancellationToken::new(Arc::new(Metrics::new())),
-            last_config_reload_epoch: 0,
             cancel_counter: 0,
             taiko: Arc::new(TaikoMock {
                 end_of_sequencing_block_hash: B256::ZERO,
@@ -961,43 +882,9 @@ mod tests {
                 current_operator_address: PRECONFER_ADDRESS,
                 next_operator_address: PRECONFER_ADDRESS,
                 taiko_inbox_height: 1000,
-                handover_window_slots: HANDOVER_WINDOW_SLOTS,
             }),
             slot_clock: Arc::new(slot_clock),
             handover_window_slots: HANDOVER_WINDOW_SLOTS,
-            handover_window_slots_default: HANDOVER_WINDOW_SLOTS,
-            handover_start_buffer_ms: 1000,
-            next_operator: false,
-            continuing_role: false,
-            simulate_not_submitting_at_the_end_of_epoch: false,
-            was_synced_preconfer: false,
-            current_operator_address: Address::ZERO,
-            last_ejection_timestamp: None,
-            ejection_grace_period_sec: 4,
-        }
-    }
-
-    fn create_operator_with_long_handover_window_from_config()
-    -> Operator<ExecutionLayerMock, MockClock, TaikoMock> {
-        let mut slot_clock = SlotClock::<MockClock>::new(0, 0, 12, 32, 2000);
-        slot_clock.clock.timestamp = 32 * 12 + 25 * 12; // second epoch 26th slot
-        Operator {
-            fork_info: ForkInfo::default(),
-            cancel_token: CancellationToken::new(Arc::new(Metrics::new())),
-            last_config_reload_epoch: 0,
-            cancel_counter: 0,
-            taiko: Arc::new(TaikoMock {
-                end_of_sequencing_block_hash: B256::ZERO,
-            }),
-            execution_layer: Arc::new(ExecutionLayerMock {
-                current_operator_address: PRECONFER_ADDRESS,
-                next_operator_address: OTHER_OPERATOR_ADDRESS,
-                taiko_inbox_height: 0,
-                handover_window_slots: 10,
-            }),
-            slot_clock: Arc::new(slot_clock),
-            handover_window_slots: HANDOVER_WINDOW_SLOTS,
-            handover_window_slots_default: HANDOVER_WINDOW_SLOTS,
             handover_start_buffer_ms: 1000,
             next_operator: false,
             continuing_role: false,
@@ -1016,7 +903,6 @@ mod tests {
         Operator {
             fork_info: ForkInfo::default(),
             cancel_token: CancellationToken::new(Arc::new(Metrics::new())),
-            last_config_reload_epoch: 0,
             cancel_counter: 0,
             taiko: Arc::new(TaikoMock {
                 end_of_sequencing_block_hash: B256::ZERO,
@@ -1024,7 +910,6 @@ mod tests {
             execution_layer,
             slot_clock: Arc::new(slot_clock),
             handover_window_slots: HANDOVER_WINDOW_SLOTS,
-            handover_window_slots_default: HANDOVER_WINDOW_SLOTS,
             handover_start_buffer_ms: 1000,
             next_operator: true,
             continuing_role: false,
@@ -1056,7 +941,6 @@ mod tests {
                 },
             },
             cancel_token: CancellationToken::new(Arc::new(Metrics::new())),
-            last_config_reload_epoch: 0,
             cancel_counter: 0,
             taiko: Arc::new(TaikoMock {
                 end_of_sequencing_block_hash: B256::ZERO,
@@ -1065,11 +949,9 @@ mod tests {
                 current_operator_address: PRECONFER_ADDRESS,
                 next_operator_address: PRECONFER_ADDRESS,
                 taiko_inbox_height: 0,
-                handover_window_slots: HANDOVER_WINDOW_SLOTS,
             }),
             slot_clock: Arc::new(slot_clock),
             handover_window_slots: HANDOVER_WINDOW_SLOTS,
-            handover_window_slots_default: HANDOVER_WINDOW_SLOTS,
             handover_start_buffer_ms: 1000,
             next_operator: false,
             continuing_role: false,
@@ -1091,7 +973,6 @@ mod tests {
         Operator {
             fork_info: ForkInfo::default(),
             cancel_token: CancellationToken::new(Arc::new(Metrics::new())),
-            last_config_reload_epoch: 0,
             cancel_counter: 0,
             taiko: Arc::new(TaikoMock {
                 end_of_sequencing_block_hash: B256::ZERO,
@@ -1100,11 +981,9 @@ mod tests {
                 current_operator_address: PRECONFER_ADDRESS,
                 next_operator_address: PRECONFER_ADDRESS,
                 taiko_inbox_height: 0,
-                handover_window_slots: HANDOVER_WINDOW_SLOTS,
             }),
             slot_clock: Arc::new(slot_clock),
             handover_window_slots: HANDOVER_WINDOW_SLOTS,
-            handover_window_slots_default: HANDOVER_WINDOW_SLOTS,
             handover_start_buffer_ms: 1000,
             next_operator: false,
             continuing_role: false,

--- a/pacaya/src/node/operator/tests.rs
+++ b/pacaya/src/node/operator/tests.rs
@@ -28,7 +28,6 @@ mod tests {
     struct ExecutionLayerMock {
         current_operator_address: Address,
         next_operator_address: Address,
-        is_preconf_router_specified: bool,
         taiko_inbox_height: u64,
         handover_window_slots: u64,
     }
@@ -44,10 +43,6 @@ mod tests {
             _: u64,
         ) -> Result<(Address, Address), OperatorError> {
             Ok((self.current_operator_address, self.next_operator_address))
-        }
-
-        async fn is_preconf_router_specified_in_taiko_wrapper(&self) -> Result<bool, Error> {
-            Ok(self.is_preconf_router_specified)
         }
 
         async fn get_l2_height_from_taiko_inbox(&self) -> Result<u64, Error> {
@@ -73,10 +68,6 @@ mod tests {
             Err(OperatorError::Any(Error::from(anyhow::anyhow!(
                 "test error"
             ))))
-        }
-
-        async fn is_preconf_router_specified_in_taiko_wrapper(&self) -> Result<bool, Error> {
-            Err(Error::from(anyhow::anyhow!("test error")))
         }
 
         async fn get_l2_height_from_taiko_inbox(&self) -> Result<u64, Error> {
@@ -128,38 +119,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_preconf_router_not_specified() {
-        let mut operator = create_operator(
-            32 * 12 + 2, // first l1 slot, second l2 slot
-            true,
-            false,
-            false,
-        );
-        operator.next_operator = true;
-        operator.was_synced_preconfer = true;
-        operator.continuing_role = false;
-        assert_eq!(
-            operator.get_status(&get_l2_slot_info()).await.unwrap(),
-            Status::new(
-                false,
-                false,
-                false,
-                false,
-                false,
-                #[cfg(feature = "get_status_duration")]
-                None,
-            ),
-        );
-    }
-
-    #[tokio::test]
     async fn test_end_of_sequencing() {
         // End of sequencing
         let mut operator = create_operator(
             (31u64 - HANDOVER_WINDOW_SLOTS) * 12 + 5 * 2, // l1 slot before handover window, 5th l2 slot
             true,
             false,
-            true,
         );
         operator.next_operator = false;
         operator.was_synced_preconfer = true;
@@ -181,7 +146,6 @@ mod tests {
             (31 - HANDOVER_WINDOW_SLOTS) * 12 + 5 * 2, // l1 slot before handover window, 5th l2 slot
             false,
             false,
-            true,
         );
         operator.next_operator = false;
         operator.was_synced_preconfer = false;
@@ -201,7 +165,6 @@ mod tests {
         // Continuing role
         let mut operator = create_operator(
             (31 - HANDOVER_WINDOW_SLOTS) * 12 + 5 * 2, // l1 slot before handover window, 5th l2 slot
-            true,
             true,
             true,
         );
@@ -225,7 +188,6 @@ mod tests {
             (31 - HANDOVER_WINDOW_SLOTS) * 12 + 4 * 2, // l1 slot before handover window, 4th l2 slot
             true,
             false,
-            true,
         );
         operator.next_operator = false;
         operator.was_synced_preconfer = true;
@@ -250,7 +212,6 @@ mod tests {
             32 * 12 + 2, // first l1 slot, second l2 slot
             true,
             false,
-            true,
         );
         operator.next_operator = true;
         operator.was_synced_preconfer = true;
@@ -272,7 +233,6 @@ mod tests {
             32 * 12 + 2, // first l1 slot, second l2 slot
             false,
             false,
-            true,
         );
         operator.was_synced_preconfer = true;
         operator.continuing_role = true;
@@ -296,7 +256,6 @@ mod tests {
             32 * 12 + 12 + 2, // second l1 slot, second l2 slot
             true,
             false,
-            true,
         );
         operator.next_operator = true;
         operator.was_synced_preconfer = true;
@@ -317,7 +276,6 @@ mod tests {
             32 * 12 + 12 + 2, // second l1 slot, second l2 slot
             false,
             false,
-            true,
         );
         operator.was_synced_preconfer = true;
         assert_eq!(
@@ -339,7 +297,6 @@ mod tests {
         let mut operator = create_operator_with_unsynced_driver_and_geth(
             31 * 12, // last slot of epoch
             false,
-            true,
             true,
         );
         operator.was_synced_preconfer = true;
@@ -377,7 +334,6 @@ mod tests {
             31 * 12, // last slot of epoch
             false,
             true,
-            true,
         );
         assert_eq!(
             operator.get_status(&get_l2_slot_info()).await.unwrap(),
@@ -396,7 +352,6 @@ mod tests {
             32 * 12, // first slot of next epoch
             true,
             false,
-            true,
         );
         operator.next_operator = true;
         operator.was_synced_preconfer = true;
@@ -418,7 +373,6 @@ mod tests {
             32 * 12, // first slot of next epoch
             true,
             false,
-            true,
         );
         operator.next_operator = true;
         operator.was_synced_preconfer = true;
@@ -444,7 +398,6 @@ mod tests {
             20 * 12, // middle of epoch
             false,
             false,
-            true,
         );
         assert_eq!(
             operator.get_status(&get_l2_slot_info()).await.unwrap(),
@@ -464,7 +417,6 @@ mod tests {
             32 * 12, // first slot of next epoch
             false,
             false,
-            true,
         );
         assert_eq!(
             operator.get_status(&get_l2_slot_info()).await.unwrap(),
@@ -483,7 +435,6 @@ mod tests {
             31 * 12, // last slot
             false,
             false,
-            true,
         );
         assert_eq!(
             operator.get_status(&get_l2_slot_info()).await.unwrap(),
@@ -506,7 +457,6 @@ mod tests {
             (32 - HANDOVER_WINDOW_SLOTS) * 12, // handover buffer
             false,
             true,
-            true,
         );
         // Override the handover start buffer to be larger than the mock timestamp
         assert_eq!(
@@ -525,7 +475,6 @@ mod tests {
         let mut operator = create_operator(
             (32 - HANDOVER_WINDOW_SLOTS + 1) * 12, // handover window after the buffer
             false,
-            true,
             true,
         );
         // Override the handover start buffer to be larger than the mock timestamp
@@ -549,7 +498,6 @@ mod tests {
         let mut operator = create_operator_with_end_of_sequencing_marker_received(
             (32 - HANDOVER_WINDOW_SLOTS) * 12, // handover buffer
             false,
-            true,
             true,
         );
         // Override the handover start buffer to be larger than the mock timestamp
@@ -577,7 +525,6 @@ mod tests {
             31 * 12, // last slot of epoch (handover window)
             true,
             true,
-            true,
         );
         assert_eq!(
             operator.get_status(&get_l2_slot_info()).await.unwrap(),
@@ -597,7 +544,6 @@ mod tests {
             20 * 12, // middle of epoch
             true,
             false,
-            true,
         );
         assert_eq!(
             operator.get_status(&get_l2_slot_info()).await.unwrap(),
@@ -662,10 +608,6 @@ mod tests {
             Err(OperatorError::OperatorCheckTooEarly)
         }
 
-        async fn is_preconf_router_specified_in_taiko_wrapper(&self) -> Result<bool, Error> {
-            Ok(true)
-        }
-
         async fn get_l2_height_from_taiko_inbox(&self) -> Result<u64, Error> {
             Ok(0)
         }
@@ -702,7 +644,6 @@ mod tests {
             31 * 12, // last slot of epoch
             true,
             false,
-            true,
         );
         assert_eq!(
             operator.get_status(&get_l2_slot_info()).await.unwrap(),
@@ -722,7 +663,7 @@ mod tests {
     async fn test_get_l1_statuses_for_operator_continuing_role() {
         let mut operator = create_operator(
             0, // first slot of epoch
-            true, true, true,
+            true, true,
         );
         operator.next_operator = true;
         operator.continuing_role = true;
@@ -743,7 +684,7 @@ mod tests {
 
         let mut operator = create_operator(
             12, // second slot of epoch
-            true, true, true,
+            true, true,
         );
         operator.next_operator = true;
         operator.continuing_role = true;
@@ -763,7 +704,6 @@ mod tests {
 
         let mut operator = create_operator(
             2 * 12, // third slot of epoch
-            true,
             true,
             true,
         );
@@ -788,7 +728,6 @@ mod tests {
         let mut operator = create_operator(
             31 * 12, // last slot of epoch
             false,
-            true,
             true,
         );
         operator.was_synced_preconfer = false;
@@ -886,7 +825,6 @@ mod tests {
         timestamp: u64,
         current_operator: bool,
         next_operator: bool,
-        is_preconf_router_specified: bool,
     ) -> Operator<ExecutionLayerMock, MockClock, TaikoMock> {
         let mut slot_clock = SlotClock::<MockClock>::new(0, 0, 12, 32, 2000);
         slot_clock.clock.timestamp = timestamp;
@@ -903,7 +841,6 @@ mod tests {
             execution_layer: Arc::new(ExecutionLayerMock {
                 current_operator_address,
                 next_operator_address,
-                is_preconf_router_specified,
                 taiko_inbox_height: 0,
                 handover_window_slots: HANDOVER_WINDOW_SLOTS,
             }),
@@ -939,7 +876,6 @@ mod tests {
         timestamp: u64,
         current_operator: bool,
         next_operator: bool,
-        is_preconf_router_specified: bool,
     ) -> Operator<ExecutionLayerMock, MockClock, TaikoMock> {
         let mut slot_clock = SlotClock::<MockClock>::new(0, 0, 12, 32, 2000);
         slot_clock.clock.timestamp = timestamp;
@@ -955,7 +891,6 @@ mod tests {
             execution_layer: Arc::new(ExecutionLayerMock {
                 current_operator_address,
                 next_operator_address,
-                is_preconf_router_specified,
                 taiko_inbox_height: 0,
                 handover_window_slots: HANDOVER_WINDOW_SLOTS,
             }),
@@ -978,7 +913,6 @@ mod tests {
         timestamp: u64,
         current_operator: bool,
         next_operator: bool,
-        is_preconf_router_specified: bool,
     ) -> Operator<ExecutionLayerMock, MockClock, TaikoUnsyncedMock> {
         let mut slot_clock = SlotClock::<MockClock>::new(0, 0, 12, 32, 2000);
         slot_clock.clock.timestamp = timestamp;
@@ -994,7 +928,6 @@ mod tests {
             execution_layer: Arc::new(ExecutionLayerMock {
                 current_operator_address,
                 next_operator_address,
-                is_preconf_router_specified,
                 taiko_inbox_height: 0,
                 handover_window_slots: HANDOVER_WINDOW_SLOTS,
             }),
@@ -1027,7 +960,6 @@ mod tests {
             execution_layer: Arc::new(ExecutionLayerMock {
                 current_operator_address: PRECONFER_ADDRESS,
                 next_operator_address: PRECONFER_ADDRESS,
-                is_preconf_router_specified: true,
                 taiko_inbox_height: 1000,
                 handover_window_slots: HANDOVER_WINDOW_SLOTS,
             }),
@@ -1060,7 +992,6 @@ mod tests {
             execution_layer: Arc::new(ExecutionLayerMock {
                 current_operator_address: PRECONFER_ADDRESS,
                 next_operator_address: OTHER_OPERATOR_ADDRESS,
-                is_preconf_router_specified: true,
                 taiko_inbox_height: 0,
                 handover_window_slots: 10,
             }),
@@ -1133,7 +1064,6 @@ mod tests {
             execution_layer: Arc::new(ExecutionLayerMock {
                 current_operator_address: PRECONFER_ADDRESS,
                 next_operator_address: PRECONFER_ADDRESS,
-                is_preconf_router_specified: true,
                 taiko_inbox_height: 0,
                 handover_window_slots: HANDOVER_WINDOW_SLOTS,
             }),
@@ -1169,7 +1099,6 @@ mod tests {
             execution_layer: Arc::new(ExecutionLayerMock {
                 current_operator_address: PRECONFER_ADDRESS,
                 next_operator_address: PRECONFER_ADDRESS,
-                is_preconf_router_specified: true,
                 taiko_inbox_height: 0,
                 handover_window_slots: HANDOVER_WINDOW_SLOTS,
             }),

--- a/realtime/src/l1/execution_layer.rs
+++ b/realtime/src/l1/execution_layer.rs
@@ -202,10 +202,6 @@ impl PreconfOperator for ExecutionLayer {
         Ok((self.preconfer_address, self.preconfer_address))
     }
 
-    async fn is_preconf_router_specified_in_taiko_wrapper(&self) -> Result<bool, Error> {
-        Ok(true)
-    }
-
     async fn get_l2_height_from_taiko_inbox(&self) -> Result<u64, Error> {
         Ok(0)
     }

--- a/realtime/src/l1/execution_layer.rs
+++ b/realtime/src/l1/execution_layer.rs
@@ -205,12 +205,6 @@ impl PreconfOperator for ExecutionLayer {
     async fn get_l2_height_from_taiko_inbox(&self) -> Result<u64, Error> {
         Ok(0)
     }
-
-    async fn get_handover_window_slots(&self) -> Result<u64, Error> {
-        Err(anyhow::anyhow!(
-            "Not implemented for RealTime execution layer"
-        ))
-    }
 }
 
 impl ExecutionLayer {

--- a/shasta/src/l1/execution_layer.rs
+++ b/shasta/src/l1/execution_layer.rs
@@ -164,14 +164,6 @@ impl PreconfOperator for ExecutionLayer {
         // It requires multiple RPC calls that we want to skip for every heartbeat in Shasta.
         Ok(0)
     }
-
-    async fn get_handover_window_slots(&self) -> Result<u64, Error> {
-        // Return a constant value from node config for Shasta
-        // since we don't have access to the TaikoWrapper contract in Shasta.
-        Err(anyhow::anyhow!(
-            "Not implemented for Shasta execution layer"
-        ))
-    }
 }
 
 impl ExecutionLayer {

--- a/shasta/src/l1/execution_layer.rs
+++ b/shasta/src/l1/execution_layer.rs
@@ -159,11 +159,6 @@ impl PreconfOperator for ExecutionLayer {
             .await
     }
 
-    async fn is_preconf_router_specified_in_taiko_wrapper(&self) -> Result<bool, Error> {
-        // Return true for Shasta because we want to skip that check in the operator crate
-        Ok(true)
-    }
-
     async fn get_l2_height_from_taiko_inbox(&self) -> Result<u64, Error> {
         // Retrieving the L2 height directly from the Inbox is not supported in Shasta.
         // It requires multiple RPC calls that we want to skip for every heartbeat in Shasta.


### PR DESCRIPTION
- Remove the check that `PreconfRouter` is configured in `TaikoWrapper` contract.
- Remove reading `HANDOVER_WINDOW` from `PreconfRouter` contract.